### PR TITLE
ログイン画面を追加

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,7 +27,7 @@ const App: React.FC = () => {
     try {
       const res = await getCurrentUser()
       if (res && res.data) {
-        const { email, name, nickname, image } = res.data.data
+        const { email, name, nickname, image } = res.data
         dispatch(setCurrentUser({ email, name, nickname, image }))
       }
     } catch (err) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import { BrowserRouter as Router, Route, Routes } from 'react-router-dom'
 import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux'
 
@@ -9,6 +9,8 @@ import { Confirm } from './components/pages/Confirm'
 import { Error } from './components/pages/Error'
 import { PrivateRoute } from './components/pages/PrivateRoute'
 import { AppDispatch, RootState } from './redux/store'
+import { getCurrentUser } from './lib/api/auth'
+import { setCurrentUser } from './redux/userSlice'
 
 export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector
 export const useAppDispatch = () => useDispatch<AppDispatch>()
@@ -17,6 +19,24 @@ const homeUrl = process.env.PUBLIC_URL
 
 const App: React.FC = () => {
   const isLogined = useAppSelector((state) => state.user.isLogined)
+  const dispatch = useAppDispatch()
+
+  const handleGetCurrentUser = async () => {
+    try {
+      const res = await getCurrentUser()
+      if (res && res.data) {
+        const { email, name, nickname, image } = res.data.data
+        dispatch(setCurrentUser({ email, name, nickname, image }))
+      }
+    } catch (err) {
+      console.error(err)
+    }
+  }
+
+  useEffect(() => {
+    void handleGetCurrentUser()
+  }, [dispatch])
+
   return (
     <Router>
       <Routes>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,16 +1,22 @@
 import React from 'react'
 import { BrowserRouter as Router, Route, Routes } from 'react-router-dom'
+import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux'
+
 import { Home } from './components/pages/Home'
 import { SignUp } from './components/pages/SignUp'
 import { Login } from './components/pages/Login'
 import { Confirm } from './components/pages/Confirm'
 import { Error } from './components/pages/Error'
 import { PrivateRoute } from './components/pages/PrivateRoute'
+import { AppDispatch, RootState } from './redux/store'
+
+export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector
+export const useAppDispatch = () => useDispatch<AppDispatch>()
 
 const homeUrl = process.env.PUBLIC_URL
 
 const App: React.FC = () => {
-  const isLogined = false
+  const isLogined = useAppSelector((state) => state.user.isLogined)
   return (
     <Router>
       <Routes>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { BrowserRouter as Router, Route, Routes } from 'react-router-dom'
 import { Home } from './components/pages/Home'
 import { SignUp } from './components/pages/SignUp'
-import { SignIn } from './components/pages/SignIn'
+import { Login } from './components/pages/Login'
 import { Confirm } from './components/pages/Confirm'
 import { Error } from './components/pages/Error'
 import { PrivateRoute } from './components/pages/PrivateRoute'
@@ -16,7 +16,7 @@ const App: React.FC = () => {
       <Routes>
         {/* public route */}
         <Route path={homeUrl + '/registration'} element={<SignUp />} />
-        <Route path={homeUrl + '/login'} element={<SignIn />} />
+        <Route path={homeUrl + '/login'} element={<Login />} />
         <Route path={homeUrl + '/confirm'} element={<Confirm />} />
 
         {/* private route */}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,18 +2,28 @@ import React from 'react'
 import { BrowserRouter as Router, Route, Routes } from 'react-router-dom'
 import { Home } from './components/pages/Home'
 import { SignUp } from './components/pages/SignUp'
+import { SignIn } from './components/pages/SignIn'
 import { Confirm } from './components/pages/Confirm'
 import { Error } from './components/pages/Error'
+import { PrivateRoute } from './components/pages/PrivateRoute'
 
 const homeUrl = process.env.PUBLIC_URL
 
 const App: React.FC = () => {
+  const isLogined = false
   return (
     <Router>
       <Routes>
-        <Route path={homeUrl} element={<Home />} />
+        {/* public route */}
         <Route path={homeUrl + '/registration'} element={<SignUp />} />
+        <Route path={homeUrl + '/login'} element={<SignIn />} />
         <Route path={homeUrl + '/confirm'} element={<Confirm />} />
+
+        {/* private route */}
+        <Route
+          path={homeUrl}
+          element={<PrivateRoute isLogined={isLogined} children={<Home />} />}
+        />
         <Route path="*" element={<Error />} />
       </Routes>
     </Router>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import { PrivateRoute } from './components/pages/PrivateRoute'
 import { AppDispatch, RootState } from './redux/store'
 import { getCurrentUser } from './lib/api/auth'
 import { setCurrentUser } from './redux/userSlice'
+import { Loading } from './components/pages/Loading'
 
 export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector
 export const useAppDispatch = () => useDispatch<AppDispatch>()
@@ -18,10 +19,11 @@ export const useAppDispatch = () => useDispatch<AppDispatch>()
 const homeUrl = process.env.PUBLIC_URL
 
 const App: React.FC = () => {
-  const isLogined = useAppSelector((state) => state.user.isLogined)
   const dispatch = useAppDispatch()
+  const [loading, setLoading] = React.useState<boolean>(true)
 
   const handleGetCurrentUser = async () => {
+    setLoading(true)
     try {
       const res = await getCurrentUser()
       if (res && res.data) {
@@ -30,12 +32,18 @@ const App: React.FC = () => {
       }
     } catch (err) {
       console.error(err)
+    } finally {
+      setLoading(false)
     }
   }
 
   useEffect(() => {
     void handleGetCurrentUser()
   }, [dispatch])
+
+  if (loading) {
+    return <Loading />
+  }
 
   return (
     <Router>
@@ -46,10 +54,7 @@ const App: React.FC = () => {
         <Route path={homeUrl + '/confirm'} element={<Confirm />} />
 
         {/* private route */}
-        <Route
-          path={homeUrl}
-          element={<PrivateRoute isLogined={isLogined} children={<Home />} />}
-        />
+        <Route path={homeUrl} element={<PrivateRoute children={<Home />} />} />
         <Route path="*" element={<Error />} />
       </Routes>
     </Router>

--- a/src/components/organisms/LoadingSpin.tsx
+++ b/src/components/organisms/LoadingSpin.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import styled from 'styled-components'
 
 export const LoadingSpin: React.FC = () => {
-  return <StyledLoading></StyledLoading>
+  return <StyledLoading />
 }
 
 const StyledLoading = styled.div`

--- a/src/components/organisms/LoadingSpin.tsx
+++ b/src/components/organisms/LoadingSpin.tsx
@@ -1,0 +1,24 @@
+import React from 'react'
+import styled from 'styled-components'
+
+export const LoadingSpin: React.FC = () => {
+  return <StyledLoading></StyledLoading>
+}
+
+const StyledLoading = styled.div`
+  border: 16px solid #f3f3f3; // Light grey
+  border-top: 16px solid #3498db; // Blue
+  border-radius: 50%;
+  width: 50px;
+  height: 50px;
+  animation: spin 2s linear infinite;
+
+  @keyframes spin {
+    0% {
+      transform: rotate(0deg);
+    }
+    100% {
+      transform: rotate(360deg);
+    }
+  }
+`

--- a/src/components/pages/Confirm.tsx
+++ b/src/components/pages/Confirm.tsx
@@ -2,10 +2,12 @@ import React from 'react'
 import styled from 'styled-components'
 
 export const Confirm: React.FC = () => {
+  const homeUrl = process.env.PUBLIC_URL
+
   return (
     <StyledConfirm>
       <h2>メール認証が完了しました</h2>
-      <a href="/login">ログインする</a>
+      <a href={homeUrl + '/login'}>ログインする</a>
     </StyledConfirm>
   )
 }

--- a/src/components/pages/Loading.tsx
+++ b/src/components/pages/Loading.tsx
@@ -1,0 +1,19 @@
+import React from 'react'
+import styled from 'styled-components'
+import { LoadingSpin } from '../organisms/LoadingSpin'
+
+export const Loading: React.FC = () => {
+  return (
+    <StyledLoading>
+      <LoadingSpin />
+    </StyledLoading>
+  )
+}
+
+const StyledLoading = styled.div`
+  width: 100%;
+  height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`

--- a/src/components/pages/Login.tsx
+++ b/src/components/pages/Login.tsx
@@ -1,5 +1,7 @@
 import React from 'react'
 import styled from 'styled-components'
+import Cookies from 'js-cookie'
+import { useNavigate } from 'react-router-dom'
 
 import { ErrorMessage } from '../organisms/ErrorMessage'
 import { LoginParams } from '../../types'
@@ -7,12 +9,15 @@ import { login } from '../../lib/api/auth'
 import { setLogin } from '../../redux/userSlice'
 import { useAppDispatch } from '../../App'
 
+const homeUrl = process.env.PUBLIC_URL
+
 export const Login: React.FC = () => {
   const [email, setEmail] = React.useState('')
   const [password, setPassword] = React.useState('')
   const [errorMessage, setErrorMessage] = React.useState<string | null>(null)
 
   const dispatch = useAppDispatch()
+  const navigate = useNavigate()
 
   const handleSignIn = (e: React.FormEvent) => {
     e.preventDefault()
@@ -25,9 +30,20 @@ export const Login: React.FC = () => {
     login(params)
       .then((res) => {
         if (res.status === 200) {
+          Cookies.set('_access_token', res.headers['access-token'] as string, {
+            secure: true,
+          })
+          Cookies.set('_client', res.headers['client'] as string, {
+            secure: true,
+          })
+          Cookies.set('_uid', res.headers['uid'] as string, { secure: true })
+
           const { email, name, nickname, image } = res.data.data
           dispatch(setLogin({ email, name, nickname, image }))
           setErrorMessage(null)
+
+          // ホーム画面に遷移させる
+          navigate(homeUrl)
         } else {
           setErrorMessage('ログインに失敗しました')
         }

--- a/src/components/pages/Login.tsx
+++ b/src/components/pages/Login.tsx
@@ -1,13 +1,18 @@
 import React from 'react'
 import styled from 'styled-components'
+
 import { ErrorMessage } from '../organisms/ErrorMessage'
 import { LoginParams } from '../../types'
 import { login } from '../../lib/api/auth'
+import { setLogin } from '../../redux/userSlice'
+import { useAppDispatch } from '../../App'
 
 export const Login: React.FC = () => {
   const [email, setEmail] = React.useState('')
   const [password, setPassword] = React.useState('')
   const [errorMessage, setErrorMessage] = React.useState<string | null>(null)
+
+  const dispatch = useAppDispatch()
 
   const handleSignIn = (e: React.FormEvent) => {
     e.preventDefault()
@@ -17,12 +22,11 @@ export const Login: React.FC = () => {
       password: password,
     }
 
-    console.log(params)
-
     login(params)
       .then((res) => {
         if (res.status === 200) {
-          console.log('ログイン成功')
+          const { email, name, nickname, image } = res.data.data
+          dispatch(setLogin({ email, name, nickname, image }))
           setErrorMessage(null)
         } else {
           setErrorMessage('ログインに失敗しました')
@@ -32,7 +36,7 @@ export const Login: React.FC = () => {
         if (typeof err.response?.data?.errors[0] === 'string') {
           setErrorMessage(err.response.data.errors[0])
         } else {
-          console.log(err)
+          console.error(err)
           setErrorMessage('不明なエラー。しばらく時間をおいて試してください。')
         }
       })

--- a/src/components/pages/Login.tsx
+++ b/src/components/pages/Login.tsx
@@ -6,7 +6,7 @@ import { useNavigate } from 'react-router-dom'
 import { ErrorMessage } from '../organisms/ErrorMessage'
 import { LoginParams } from '../../types'
 import { login } from '../../lib/api/auth'
-import { setLogin } from '../../redux/userSlice'
+import { setCurrentUser } from '../../redux/userSlice'
 import { useAppDispatch } from '../../App'
 
 const homeUrl = process.env.PUBLIC_URL
@@ -39,7 +39,7 @@ export const Login: React.FC = () => {
           Cookies.set('_uid', res.headers['uid'] as string, { secure: true })
 
           const { email, name, nickname, image } = res.data.data
-          dispatch(setLogin({ email, name, nickname, image }))
+          dispatch(setCurrentUser({ email, name, nickname, image }))
           setErrorMessage(null)
 
           // ホーム画面に遷移させる

--- a/src/components/pages/Login.tsx
+++ b/src/components/pages/Login.tsx
@@ -1,8 +1,10 @@
 import React from 'react'
 import styled from 'styled-components'
 import { ErrorMessage } from '../organisms/ErrorMessage'
+import { LoginParams } from '../../types'
+import { login } from '../../lib/api/auth'
 
-export const SignIn: React.FC = () => {
+export const Login: React.FC = () => {
   const [email, setEmail] = React.useState('')
   const [password, setPassword] = React.useState('')
   const [errorMessage, setErrorMessage] = React.useState<string | null>(null)
@@ -10,8 +12,30 @@ export const SignIn: React.FC = () => {
   const handleSignIn = (e: React.FormEvent) => {
     e.preventDefault()
 
-    setErrorMessage('エラーです')
-    console.log('ログイン処理')
+    const params: LoginParams = {
+      email: email,
+      password: password,
+    }
+
+    console.log(params)
+
+    login(params)
+      .then((res) => {
+        if (res.status === 200) {
+          console.log('ログイン成功')
+          setErrorMessage(null)
+        } else {
+          setErrorMessage('ログインに失敗しました')
+        }
+      })
+      .catch((err) => {
+        if (typeof err.response?.data?.errors[0] === 'string') {
+          setErrorMessage(err.response.data.errors[0])
+        } else {
+          console.log(err)
+          setErrorMessage('不明なエラー。しばらく時間をおいて試してください。')
+        }
+      })
   }
 
   return (

--- a/src/components/pages/Login.tsx
+++ b/src/components/pages/Login.tsx
@@ -16,7 +16,7 @@ export const Login: React.FC = () => {
     email: '',
     password: '',
   })
-  const [errorMessage, setErrorMessage] = React.useState<string | null>(null)
+  const [errorMessage, setErrorMessage] = React.useState<string>('')
 
   const dispatch = useAppDispatch()
   const navigate = useNavigate()
@@ -47,7 +47,7 @@ export const Login: React.FC = () => {
 
           const { email, name, nickname, image } = res.data.data
           dispatch(setCurrentUser({ email, name, nickname, image }))
-          setErrorMessage(null)
+          setErrorMessage('')
 
           // ホーム画面に遷移させる
           navigate(homeUrl)
@@ -90,7 +90,7 @@ export const Login: React.FC = () => {
           />
         </div>
         <button type="submit">ログイン</button>
-        {errorMessage && <ErrorMessage>{errorMessage}</ErrorMessage>}
+        {errorMessage !== '' && <ErrorMessage>{errorMessage}</ErrorMessage>}
       </form>
     </StyledSignIn>
   )

--- a/src/components/pages/Login.tsx
+++ b/src/components/pages/Login.tsx
@@ -12,19 +12,26 @@ import { useAppDispatch } from '../../App'
 const homeUrl = process.env.PUBLIC_URL
 
 export const Login: React.FC = () => {
-  const [email, setEmail] = React.useState('')
-  const [password, setPassword] = React.useState('')
+  const [loginInput, setLoginInput] = React.useState({
+    email: '',
+    password: '',
+  })
   const [errorMessage, setErrorMessage] = React.useState<string | null>(null)
 
   const dispatch = useAppDispatch()
   const navigate = useNavigate()
 
+  const onChangeLoginInput = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target
+    setLoginInput({ ...loginInput, [name]: value })
+  }
+
   const handleSignIn = (e: React.FormEvent) => {
     e.preventDefault()
 
     const params: LoginParams = {
-      email: email,
-      password: password,
+      email: loginInput.email,
+      password: loginInput.password,
     }
 
     login(params)
@@ -66,18 +73,20 @@ export const Login: React.FC = () => {
           <label htmlFor="email">メールアドレス</label>
           <input
             id="email"
+            name="email"
             type="email"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
+            value={loginInput.email}
+            onChange={onChangeLoginInput}
           />
         </div>
         <div>
           <label htmlFor="password">パスワード</label>
           <input
             id="password"
+            name="password"
             type="password"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
+            value={loginInput.password}
+            onChange={onChangeLoginInput}
           />
         </div>
         <button type="submit">ログイン</button>

--- a/src/components/pages/PrivateRoute.tsx
+++ b/src/components/pages/PrivateRoute.tsx
@@ -1,0 +1,14 @@
+import React, { ReactNode } from 'react'
+import { Navigate } from 'react-router-dom'
+
+type Props = {
+  children: ReactNode
+  isLogined: boolean
+}
+
+const homeUrl = process.env.PUBLIC_URL
+
+export const PrivateRoute: React.FC<Props> = (props) => {
+  const { children, isLogined } = props
+  return isLogined ? <>{children}</> : <Navigate to={homeUrl + '/login'} />
+}

--- a/src/components/pages/PrivateRoute.tsx
+++ b/src/components/pages/PrivateRoute.tsx
@@ -1,14 +1,15 @@
 import React, { ReactNode } from 'react'
 import { Navigate } from 'react-router-dom'
+import { useAppSelector } from '../../App'
 
 type Props = {
   children: ReactNode
-  isLogined: boolean
 }
 
 const homeUrl = process.env.PUBLIC_URL
 
 export const PrivateRoute: React.FC<Props> = (props) => {
-  const { children, isLogined } = props
+  const { children } = props
+  const isLogined = useAppSelector((state) => state.user.isLogined)
   return isLogined ? <>{children}</> : <Navigate to={homeUrl + '/login'} />
 }

--- a/src/components/pages/SignIn.tsx
+++ b/src/components/pages/SignIn.tsx
@@ -1,0 +1,96 @@
+import React from 'react'
+import styled from 'styled-components'
+import { ErrorMessage } from '../organisms/ErrorMessage'
+
+export const SignIn: React.FC = () => {
+  const [email, setEmail] = React.useState('')
+  const [password, setPassword] = React.useState('')
+  const [errorMessage, setErrorMessage] = React.useState<string | null>(null)
+
+  const handleSignIn = (e: React.FormEvent) => {
+    e.preventDefault()
+
+    setErrorMessage('エラーです')
+    console.log('ログイン処理')
+  }
+
+  return (
+    <StyledSignIn>
+      <h2>ログイン</h2>
+      <form onSubmit={handleSignIn}>
+        <div>
+          <label htmlFor="email">メールアドレス</label>
+          <input
+            id="email"
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+          />
+        </div>
+        <div>
+          <label htmlFor="password">パスワード</label>
+          <input
+            id="password"
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+          />
+        </div>
+        <button type="submit">ログイン</button>
+        {errorMessage && <ErrorMessage>{errorMessage}</ErrorMessage>}
+      </form>
+    </StyledSignIn>
+  )
+}
+
+const StyledSignIn = styled.div`
+  width: 300px;
+  margin: 0 auto;
+  padding: 20px;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+  border-radius: 8px;
+
+  h2 {
+    text-align: center;
+    margin-bottom: 20px;
+  }
+
+  form {
+    div {
+      margin-bottom: 10px;
+    }
+
+    label {
+      display: block;
+      margin-bottom: 5px;
+    }
+
+    input {
+      width: 95%;
+      padding: 8px;
+      margin-right: 10px;
+      border: 1px solid #ccc;
+      border-radius: 4px;
+    }
+
+    button {
+      width: 100%;
+      padding: 10px;
+      background-color: #007bff;
+      color: white;
+      border: none;
+      border-radius: 4px;
+      cursor: pointer;
+      transition: background-color 0.2s;
+
+      &:hover {
+        background-color: #0056b3;
+      }
+    }
+
+    .error {
+      color: red;
+      margin-top: 10px;
+    }
+  }
+`

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,10 +1,14 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App'
+import { Provider } from 'react-redux'
+import { store } from './redux/store'
 
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement)
 root.render(
   <React.StrictMode>
-    <App />
+    <Provider store={store}>
+      <App />
+    </Provider>
   </React.StrictMode>
 )

--- a/src/lib/api/auth.ts
+++ b/src/lib/api/auth.ts
@@ -1,7 +1,12 @@
 import client from './client'
-import { SignUpParams } from '../../types/index'
+import { SignUpParams, LoginParams } from '../../types/index'
 
 // サインアップ
 export const signUp = (params: SignUpParams) => {
   return client.post('users', params)
+}
+
+// ログイン
+export const login = (params: LoginParams) => {
+  return client.post('users/sign_in', params)
 }

--- a/src/lib/api/auth.ts
+++ b/src/lib/api/auth.ts
@@ -1,3 +1,5 @@
+import Cookies from 'js-cookie'
+
 import client from './client'
 import { SignUpParams, LoginParams } from '../../types/index'
 
@@ -9,4 +11,23 @@ export const signUp = (params: SignUpParams) => {
 // ログイン
 export const login = (params: LoginParams) => {
   return client.post('users/sign_in', params)
+}
+
+// 認証済みのユーザーを取得
+export const getCurrentUser = () => {
+  if (
+    !Cookies.get('_access_token') ||
+    !Cookies.get('_client') ||
+    !Cookies.get('_uid')
+  )
+    return
+
+  // prettier-ignore
+  return client.get('/auth/sessions', {
+    headers: {
+      "access-token": Cookies.get("_access_token"),
+      "client": Cookies.get("_client"),
+      "uid": Cookies.get("_uid")
+    },
+  })
 }

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -1,0 +1,11 @@
+import { configureStore } from '@reduxjs/toolkit'
+import userReducer from './userSlice'
+
+export const store = configureStore({
+  reducer: {
+    user: userReducer,
+  },
+})
+
+export type AppDispatch = typeof store.dispatch
+export type RootState = ReturnType<typeof store.getState>

--- a/src/redux/userSlice.ts
+++ b/src/redux/userSlice.ts
@@ -1,0 +1,33 @@
+import { PayloadAction, createSlice } from '@reduxjs/toolkit'
+
+type UserInfo = {
+  email: string
+  name?: string
+  nickname?: string
+  image?: string
+}
+
+type User = {
+  isLogined: boolean
+  userInfo: UserInfo | null
+}
+
+const initialState: User = {
+  isLogined: false,
+  userInfo: null,
+}
+
+const userSlice = createSlice({
+  name: 'user',
+  initialState: initialState,
+  reducers: {
+    setLogin: (state, action: PayloadAction<UserInfo>) => {
+      state.isLogined = true
+      state.userInfo = action.payload
+    },
+  },
+})
+
+export const { setLogin } = userSlice.actions
+
+export default userSlice.reducer

--- a/src/redux/userSlice.ts
+++ b/src/redux/userSlice.ts
@@ -21,13 +21,13 @@ const userSlice = createSlice({
   name: 'user',
   initialState: initialState,
   reducers: {
-    setLogin: (state, action: PayloadAction<UserInfo>) => {
+    setCurrentUser: (state, action: PayloadAction<UserInfo>) => {
       state.isLogined = true
       state.userInfo = action.payload
     },
   },
 })
 
-export const { setLogin } = userSlice.actions
+export const { setCurrentUser } = userSlice.actions
 
 export default userSlice.reducer

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -5,3 +5,9 @@ export interface SignUpParams {
   passwordConfirmation: string
   confirmSuccessURL: string
 }
+
+// ログイン
+export interface LoginParams {
+  email: string
+  password: string
+}


### PR DESCRIPTION
## 課題のリンク

* https://github.com/happiness-chain/practice/blob/main/14.2_react/003_%E8%AA%B2%E9%A1%8C.md#%E3%83%AD%E3%82%B0%E3%82%A4%E3%83%B3%E6%A9%9F%E8%83%BD

## やったこと

* ログイン画面を実装しました
* グローバルステートの管理をReduxで行うようにしました
* 認証済みであれば、プライベートルートにアクセス可能としました

## やらなかったこと

ログアウトは未実装

## 動作確認方法

### GitHub Pagesで確認する場合
1. [ログイン画面](https://8tako8tako8.github.io/twitter_react/login)にアクセスし、ログインする
2. 認証情報が正しい場合、ルートにリダイレクトされればOK
3. クッキーにトークン等がセットされていたらOK
![image](https://github.com/8tako8tako8/twitter_react/assets/65395999/34fa0e4e-bc1d-4ab5-9b5c-b02f7bdf19a7)


## キャプチャ

なし

## その他

* バックエンドのPR
  * https://github.com/8tako8tako8/twitter_rails_api/pull/1