### PR TITLE
ホーム画面（ツイート投稿・ツイート一覧）を追加

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,38 +1,4 @@
-.App {
-  text-align: center;
-}
-
-.App-logo {
-  height: 40vmin;
-  pointer-events: none;
-}
-
-@media (prefers-reduced-motion: no-preference) {
-  .App-logo {
-    animation: App-logo-spin infinite 20s linear;
-  }
-}
-
-.App-header {
-  background-color: #282c34;
-  min-height: 100vh;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  font-size: calc(10px + 2vmin);
-  color: white;
-}
-
-.App-link {
-  color: #61dafb;
-}
-
-@keyframes App-logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
+body {
+  --twitter-color: #50b7f5;
+  --twitter-background: #e6ecf0;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import React, { useEffect } from 'react'
 import { BrowserRouter as Router, Route, Routes } from 'react-router-dom'
 import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux'
 
+import './App.css'
 import { Home } from './components/pages/Home'
 import { SignUp } from './components/pages/SignUp'
 import { Login } from './components/pages/Login'

--- a/src/components/molecules/SideBarOption.tsx
+++ b/src/components/molecules/SideBarOption.tsx
@@ -1,0 +1,51 @@
+import React from 'react'
+import styled from 'styled-components'
+
+type Props = {
+  text: string
+  Icon: React.ElementType
+  active: boolean
+}
+
+export const SideBarOption: React.FC<Props> = (props) => {
+  const { text, Icon, active } = props
+
+  return (
+    <StyledSideBarOption>
+      <div className={`sideBarOption ${active && 'sideBarOptionActive'}`}>
+        <Icon />
+        <h2>{text}</h2>
+      </div>
+    </StyledSideBarOption>
+  )
+}
+
+const StyledSideBarOption = styled.div`
+  .sideBarOption {
+    display: flex;
+    align-items: center;
+    cursor: pointer;
+    transition: color 0.15s ease-out;
+    padding-left: 20px;
+  }
+
+  .sideBarOption:hover {
+    background-color: #e8f5fe;
+    border-radius: 30px;
+    color: var(--twitter-color);
+  }
+
+  .sideBarOption > .MuiSvgIcon-root {
+    padding-right: 20px;
+  }
+
+  .sideBarOption > h2 {
+    font-size: 24px;
+    margin-right: 20px;
+    font-weight: 800;
+  }
+
+  .sideBarOptionActive {
+    color: var(--twitter-color);
+  }
+`

--- a/src/components/molecules/SideBarOption.tsx
+++ b/src/components/molecules/SideBarOption.tsx
@@ -3,17 +3,19 @@ import styled from 'styled-components'
 
 type Props = {
   text: string
-  Icon: React.ElementType
-  active: boolean
+  isActive: boolean
+  children: React.ReactNode
 }
 
-export const SideBarOption: React.FC<Props> = (props) => {
-  const { text, Icon, active } = props
-
+export const SideBarOption: React.FC<Props> = ({
+  text,
+  isActive,
+  children,
+}) => {
   return (
     <StyledSideBarOption>
-      <div className={`sideBarOption ${active && 'sideBarOptionActive'}`}>
-        <Icon />
+      <div className={`sideBarOption ${isActive && 'sideBarOptionActive'}`}>
+        {children}
         <h2>{text}</h2>
       </div>
     </StyledSideBarOption>

--- a/src/components/organisms/Post.tsx
+++ b/src/components/organisms/Post.tsx
@@ -8,26 +8,26 @@ import { Avatar } from '@mui/material'
 import React from 'react'
 import styled from 'styled-components'
 
-type Tweet = {
+type Post = {
   id: number
   user: {
     id: string
-    userName: string
-    displayName: string
+    name: string
+    nickname: string
     avatarUrl: string
   }
-  content: string
-  image: string
+  tweet: string
+  imageUrl: string
   retweets: number
   likes: number
 }
 
 type Props = {
-  tweet: Tweet
+  post: Post
 }
 
 export const Post: React.FC<Props> = (props) => {
-  const { tweet } = props
+  const { post } = props
 
   return (
     <StyledPost>
@@ -39,18 +39,18 @@ export const Post: React.FC<Props> = (props) => {
           <div className="postHeader">
             <div className="postHeaderText">
               <h3>
-                {tweet.user.displayName}
+                {post.user.nickname}
                 <span className="postHeaderSpecial">
                   <VerifiedUser className="postBadge" />
-                  {tweet.user.userName}
+                  {post.user.name}
                 </span>
               </h3>
             </div>
             <div className="postHeaderDescription">
-              <p>{tweet.content}</p>
+              <p>{post.tweet}</p>
             </div>
           </div>
-          {tweet.image && <img src={tweet.image} />}
+          {post.imageUrl && <img src={post.imageUrl} />}
           <div className="postFooter">
             <ChatBubbleOutline fontSize="small" />
             <Repeat fontSize="small" />

--- a/src/components/organisms/Post.tsx
+++ b/src/components/organisms/Post.tsx
@@ -1,0 +1,118 @@
+import {
+  ChatBubbleOutline,
+  FavoriteBorder,
+  Repeat,
+  VerifiedUser,
+} from '@mui/icons-material'
+import { Avatar } from '@mui/material'
+import React from 'react'
+import styled from 'styled-components'
+
+type Tweet = {
+  id: number
+  user: {
+    id: string
+    userName: string
+    displayName: string
+    avatarUrl: string
+  }
+  content: string
+  image: string
+  retweets: number
+  likes: number
+}
+
+type Props = {
+  tweet: Tweet
+}
+
+export const Post: React.FC<Props> = (props) => {
+  const { tweet } = props
+
+  return (
+    <StyledPost>
+      <div className="post">
+        <div className="postAvatar">
+          <Avatar />
+        </div>
+        <div className="postBody">
+          <div className="postHeader">
+            <div className="postHeaderText">
+              <h3>
+                {tweet.user.displayName}
+                <span className="postHeaderSpecial">
+                  <VerifiedUser className="postBadge" />
+                  {tweet.user.userName}
+                </span>
+              </h3>
+            </div>
+            <div className="postHeaderDescription">
+              <p>{tweet.content}</p>
+            </div>
+          </div>
+          {tweet.image && <img src={tweet.image} />}
+          <div className="postFooter">
+            <ChatBubbleOutline fontSize="small" />
+            <Repeat fontSize="small" />
+            <FavoriteBorder fontSize="small" />
+          </div>
+        </div>
+      </div>
+    </StyledPost>
+  )
+}
+
+const StyledPost = styled.div`
+  .post {
+    display: flex;
+    align-items: flex-start;
+    border-bottom: 1px solid var(--twitter-background);
+  }
+
+  .postBody {
+    flex: 1;
+  }
+
+  p {
+    margin: 0;
+    padding: 0;
+  }
+
+  .postBody > img {
+    border-radius: 20px;
+    width: 100%;
+  }
+
+  .postFooter {
+    display: flex;
+    justify-content: space-between;
+    margin-top: 10px;
+    margin-bottom: 10px;
+    margin-right: 10px;
+  }
+
+  .postHeaderDescription {
+    margin-bottom: 10px;
+    font-size: 15px;
+  }
+
+  .postHeaderText > h3 {
+    font-size: 15px;
+    margin-bottom: 5px;
+  }
+
+  .postBadge {
+    font-size: 14px !important;
+    color: var(--twitter-color);
+  }
+
+  .postHeaderSpecial {
+    font-weight: 600;
+    font-size: 12px;
+    color: gray;
+  }
+
+  .postAvatar {
+    padding: 15px;
+  }
+`

--- a/src/components/organisms/Post.tsx
+++ b/src/components/organisms/Post.tsx
@@ -71,6 +71,7 @@ const StyledPost = styled.div`
 
   .postBody {
     flex: 1;
+    min-width: 0;
   }
 
   p {
@@ -94,6 +95,8 @@ const StyledPost = styled.div`
   .postHeaderDescription {
     margin-bottom: 10px;
     font-size: 15px;
+    white-space: normal;
+    word-wrap: break-word;
   }
 
   .postHeaderText > h3 {

--- a/src/components/organisms/Posts.tsx
+++ b/src/components/organisms/Posts.tsx
@@ -57,59 +57,6 @@ export const Posts: React.FC<Props> = ({
 }
 
 const StyledPost = styled.div`
-  .post {
-    display: flex;
-    align-items: flex-start;
-    border-bottom: 1px solid var(--twitter-background);
-  }
-
-  .postBody {
-    flex: 1;
-  }
-
-  p {
-    margin: 0;
-    padding: 0;
-  }
-
-  .postBody > img {
-    border-radius: 20px;
-    width: 100%;
-  }
-
-  .postFooter {
-    display: flex;
-    justify-content: space-between;
-    margin-top: 10px;
-    margin-bottom: 10px;
-    margin-right: 10px;
-  }
-
-  .postHeaderDescription {
-    margin-bottom: 10px;
-    font-size: 15px;
-  }
-
-  .postHeaderText > h3 {
-    font-size: 15px;
-    margin-bottom: 5px;
-  }
-
-  .postBadge {
-    font-size: 14px !important;
-    color: var(--twitter-color);
-  }
-
-  .postHeaderSpecial {
-    font-weight: 600;
-    font-size: 12px;
-    color: gray;
-  }
-
-  .postAvatar {
-    padding: 15px;
-  }
-
   .pagination {
     display: flex;
     align-items: center;

--- a/src/components/organisms/Posts.tsx
+++ b/src/components/organisms/Posts.tsx
@@ -1,0 +1,113 @@
+import React, { useState } from 'react'
+import styled from 'styled-components'
+import { Post } from './Post'
+
+type Tweet = {
+  id: number
+  user: {
+    id: string
+    userName: string
+    displayName: string
+    avatarUrl: string
+  }
+  content: string
+  image: string
+  retweets: number
+  likes: number
+}
+
+const sampleTweets: Tweet[] = [
+  {
+    id: 1,
+    user: {
+      id: 'u1',
+      userName: 'aliiiiii1',
+      displayName: 'Alice',
+      avatarUrl: '/path/to/avatar1.png',
+    },
+    content: 'This is a sample tweet from Alice.',
+    image: 'https://source.unsplash.com/random',
+    retweets: 5,
+    likes: 20,
+  },
+  {
+    id: 2,
+    user: {
+      id: 'u2',
+      userName: 'booooooooc',
+      displayName: 'Bob',
+      avatarUrl: '/path/to/avatar2.png',
+    },
+    content: 'Another sample tweet, this time from Bob.',
+    image: '',
+    retweets: 10,
+    likes: 15,
+  },
+]
+
+export const Posts: React.FC = () => {
+  const [tweets] = useState<Tweet[]>(sampleTweets)
+
+  return (
+    <StyledPost>
+      {tweets.map((tweet) => (
+        <Post key={tweet.id} tweet={tweet} />
+      ))}
+    </StyledPost>
+  )
+}
+
+const StyledPost = styled.div`
+  .post {
+    display: flex;
+    align-items: flex-start;
+    border-bottom: 1px solid var(--twitter-background);
+  }
+
+  .postBody {
+    flex: 1;
+  }
+
+  p {
+    margin: 0;
+    padding: 0;
+  }
+
+  .postBody > img {
+    border-radius: 20px;
+    width: 100%;
+  }
+
+  .postFooter {
+    display: flex;
+    justify-content: space-between;
+    margin-top: 10px;
+    margin-bottom: 10px;
+    margin-right: 10px;
+  }
+
+  .postHeaderDescription {
+    margin-bottom: 10px;
+    font-size: 15px;
+  }
+
+  .postHeaderText > h3 {
+    font-size: 15px;
+    margin-bottom: 5px;
+  }
+
+  .postBadge {
+    font-size: 14px !important;
+    color: var(--twitter-color);
+  }
+
+  .postHeaderSpecial {
+    font-weight: 600;
+    font-size: 12px;
+    color: gray;
+  }
+
+  .postAvatar {
+    padding: 15px;
+  }
+`

--- a/src/components/organisms/Posts.tsx
+++ b/src/components/organisms/Posts.tsx
@@ -1,10 +1,8 @@
-import React, { useEffect, useState } from 'react'
+import React from 'react'
 import styled from 'styled-components'
 import { Post } from './Post'
-import { getPosts } from '../../lib/api/tweet'
 import { Loading } from '../pages/Loading'
 import { Pagination } from '@mui/material'
-import { useLocation, useNavigate } from 'react-router-dom'
 
 type Post = {
   id: number
@@ -20,77 +18,21 @@ type Post = {
   likes: number
 }
 
-// TODO: リツイート、いいね機能、アバター画像後に削除する
-const initialPost: Post = {
-  id: 1,
-  user: {
-    id: 'u1',
-    name: 'aliiiiii1',
-    nickname: 'Alice',
-    avatarUrl: '/path/to/avatar1.png',
-  },
-  tweet: 'This is a sample tweet from Alice.',
-  imageUrl: 'https://source.unsplash.com/random',
-  retweets: 5,
-  likes: 20,
+type Props = {
+  posts: Post[]
+  loading: boolean
+  currentPage: number
+  totalPages: number
+  handleChangePage: (_event: React.ChangeEvent<unknown>, page: number) => void
 }
 
-export const Posts: React.FC = () => {
-  const [posts, setPosts] = useState<Post[]>([])
-  const [loading, setLoading] = useState<boolean>(false)
-  const [currentPage, setCurrentPage] = React.useState(1)
-  const [totalPages, setTotalPages] = React.useState(1)
-
-  const navigate = useNavigate()
-  const location = useLocation()
-
-  const handleChangePage = (
-    _event: React.ChangeEvent<unknown>,
-    page: number
-  ) => {
-    setCurrentPage(page)
-    navigate({ ...location, search: `?page=${page}` })
-    handleGetPosts(page)
-    window.scrollTo(0, 0)
-  }
-
-  const handleGetPosts = (page: number) => {
-    setLoading(true)
-
-    getPosts(page)
-      .then((res) => {
-        if (res && res.data) {
-          setTotalPages((res.data.pagination.totalPages as number) || 1)
-          const tmpPosts: Post[] = (res.data.tweets as Post[]).map((tweet) => {
-            return {
-              ...initialPost,
-              id: tweet.id,
-              user: tweet.user,
-              tweet: tweet.tweet,
-              imageUrl: tweet.imageUrl,
-              retweets: tweet.retweets,
-              likes: tweet.likes,
-            }
-          })
-          setPosts(tmpPosts)
-        }
-      })
-      .catch((err) => {
-        console.error(err)
-      })
-      .finally(() => {
-        setLoading(false)
-      })
-  }
-
-  useEffect(() => {
-    //  クエリパラメータからpageを取得する
-    const queryParams = new URLSearchParams(location.search)
-    const page = Number(queryParams.get('page')) || 1
-    setCurrentPage(page)
-    handleGetPosts(page)
-  }, [location.search])
-
+export const Posts: React.FC<Props> = ({
+  posts,
+  loading,
+  currentPage,
+  totalPages,
+  handleChangePage,
+}) => {
   if (loading) {
     return <Loading />
   }

--- a/src/components/organisms/Posts.tsx
+++ b/src/components/organisms/Posts.tsx
@@ -1,57 +1,84 @@
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import styled from 'styled-components'
 import { Post } from './Post'
+import { getPosts } from '../../lib/api/tweet'
+import { Loading } from '../pages/Loading'
 
-type Tweet = {
+type Post = {
   id: number
   user: {
     id: string
-    userName: string
-    displayName: string
+    name: string
+    nickname: string
     avatarUrl: string
   }
-  content: string
-  image: string
+  tweet: string
+  imageUrl: string
   retweets: number
   likes: number
 }
 
-const sampleTweets: Tweet[] = [
-  {
-    id: 1,
-    user: {
-      id: 'u1',
-      userName: 'aliiiiii1',
-      displayName: 'Alice',
-      avatarUrl: '/path/to/avatar1.png',
-    },
-    content: 'This is a sample tweet from Alice.',
-    image: 'https://source.unsplash.com/random',
-    retweets: 5,
-    likes: 20,
+// TODO: リツイート、いいね機能、アバター画像後に削除する
+const initialPost: Post = {
+  id: 1,
+  user: {
+    id: 'u1',
+    name: 'aliiiiii1',
+    nickname: 'Alice',
+    avatarUrl: '/path/to/avatar1.png',
   },
-  {
-    id: 2,
-    user: {
-      id: 'u2',
-      userName: 'booooooooc',
-      displayName: 'Bob',
-      avatarUrl: '/path/to/avatar2.png',
-    },
-    content: 'Another sample tweet, this time from Bob.',
-    image: '',
-    retweets: 10,
-    likes: 15,
-  },
-]
+  tweet: 'This is a sample tweet from Alice.',
+  imageUrl: 'https://source.unsplash.com/random',
+  retweets: 5,
+  likes: 20,
+}
 
 export const Posts: React.FC = () => {
-  const [tweets] = useState<Tweet[]>(sampleTweets)
+  const [posts, setPosts] = useState<Post[]>([])
+  const [loading, setLoading] = useState<boolean>(false)
+
+  const handleGetPosts = () => {
+    setLoading(true)
+
+    getPosts()
+      .then((res) => {
+        if (res && res.data) {
+          console.log(res.data)
+          const tmpPosts: Post[] = (res.data.tweets as Post[]).map((tweet) => {
+            console.log(tweet)
+            return {
+              ...initialPost,
+              id: tweet.id,
+              user: tweet.user,
+              tweet: tweet.tweet,
+              imageUrl: tweet.imageUrl,
+              retweets: tweet.retweets,
+              likes: tweet.likes,
+            }
+          })
+          setPosts(tmpPosts)
+        }
+      })
+      .catch((err) => {
+        console.log(err)
+      })
+      .finally(() => {
+        setLoading(false)
+      })
+  }
+
+  useEffect(() => {
+    void handleGetPosts()
+  }, [])
+
+  if (loading) {
+    return <Loading />
+  }
 
   return (
     <StyledPost>
-      {tweets.map((tweet) => (
-        <Post key={tweet.id} tweet={tweet} />
+      {posts.map((post) => (
+        <Post key={post.id} post={post} />
       ))}
     </StyledPost>
   )

--- a/src/components/organisms/SideBarOptionList.tsx
+++ b/src/components/organisms/SideBarOptionList.tsx
@@ -1,0 +1,51 @@
+import React from 'react'
+import { SideBarOption } from '../molecules/SideBarOption'
+import HomeIcon from '@mui/icons-material/Home'
+import MailOutlineIcon from '@mui/icons-material/MailOutline'
+import NotificationsNoneIcon from '@mui/icons-material/NotificationsNone'
+import BookmarkBorderIcon from '@mui/icons-material/BookmarkBorder'
+import styled from 'styled-components'
+import PermIdentityIcon from '@mui/icons-material/PermIdentity'
+import MoreHorizIcon from '@mui/icons-material/MoreHoriz'
+import { useLocation } from 'react-router-dom'
+
+export const SideBarOptionList: React.FC = () => {
+  const location = useLocation()
+
+  return (
+    <StyledSideBarOptionList>
+      <SideBarOption
+        text="ホーム"
+        Icon={HomeIcon}
+        active={location.pathname === '/'}
+      />
+      <SideBarOption
+        text="通知"
+        Icon={NotificationsNoneIcon}
+        active={location.pathname === '/notifications'}
+      />
+      <SideBarOption
+        text="メッセージ"
+        Icon={MailOutlineIcon}
+        active={location.pathname === '/messages'}
+      />
+      <SideBarOption
+        text="ブックマーク"
+        Icon={BookmarkBorderIcon}
+        active={location.pathname === '/bookmarks'}
+      />
+      <SideBarOption
+        text="プロフィール"
+        Icon={PermIdentityIcon}
+        active={location.pathname === '/profile'}
+      />
+      <SideBarOption
+        text="退会"
+        Icon={MoreHorizIcon}
+        active={location.pathname === '/cancel'}
+      />
+    </StyledSideBarOptionList>
+  )
+}
+
+const StyledSideBarOptionList = styled.div``

--- a/src/components/organisms/SideBarOptionList.tsx
+++ b/src/components/organisms/SideBarOptionList.tsx
@@ -12,38 +12,42 @@ import { useLocation } from 'react-router-dom'
 export const SideBarOptionList: React.FC = () => {
   const location = useLocation()
 
+  const SIDEBAR_LIST = [
+    { text: 'ホーム', icon: HomeIcon, isActive: location.pathname === '/' },
+    {
+      text: '通知',
+      icon: NotificationsNoneIcon,
+      isActive: location.pathname === '/notifications',
+    },
+    {
+      text: 'メッセージ',
+      icon: MailOutlineIcon,
+      isActive: location.pathname === '/messages',
+    },
+    {
+      text: 'ブックマーク',
+      icon: BookmarkBorderIcon,
+      isActive: location.pathname === '/bookmarks',
+    },
+    {
+      text: 'プロフィール',
+      icon: PermIdentityIcon,
+      isActive: location.pathname === '/profile',
+    },
+    {
+      text: '退会',
+      icon: MoreHorizIcon,
+      isActive: location.pathname === '/cancel',
+    },
+  ]
+
   return (
     <StyledSideBarOptionList>
-      <SideBarOption
-        text="ホーム"
-        Icon={HomeIcon}
-        active={location.pathname === '/'}
-      />
-      <SideBarOption
-        text="通知"
-        Icon={NotificationsNoneIcon}
-        active={location.pathname === '/notifications'}
-      />
-      <SideBarOption
-        text="メッセージ"
-        Icon={MailOutlineIcon}
-        active={location.pathname === '/messages'}
-      />
-      <SideBarOption
-        text="ブックマーク"
-        Icon={BookmarkBorderIcon}
-        active={location.pathname === '/bookmarks'}
-      />
-      <SideBarOption
-        text="プロフィール"
-        Icon={PermIdentityIcon}
-        active={location.pathname === '/profile'}
-      />
-      <SideBarOption
-        text="退会"
-        Icon={MoreHorizIcon}
-        active={location.pathname === '/cancel'}
-      />
+      {SIDEBAR_LIST.map((item) => (
+        <SideBarOption text={item.text} isActive={item.isActive}>
+          <item.icon />
+        </SideBarOption>
+      ))}
     </StyledSideBarOptionList>
   )
 }

--- a/src/components/organisms/TweetBox.tsx
+++ b/src/components/organisms/TweetBox.tsx
@@ -4,11 +4,20 @@ import { Avatar } from '@mui/material'
 import { Button } from '@mui/material'
 import { postTweet, postTweetImage } from '../../lib/api/tweet'
 import { ErrorMessage } from './ErrorMessage'
+import { useNavigate } from 'react-router-dom'
 
-export const TweetBox: React.FC = () => {
+const homeUrl = process.env.PUBLIC_URL
+
+type Props = {
+  handleGetPosts: (page: number) => void
+}
+
+export const TweetBox: React.FC<Props> = ({ handleGetPosts }) => {
   const [tweetMessage, setTweetMessage] = useState('')
   const [tweetImage, setTweetImage] = useState<File | null>(null)
   const [errorMessage, setErrorMessage] = useState('')
+
+  const navigate = useNavigate()
 
   const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0]
@@ -41,6 +50,15 @@ export const TweetBox: React.FC = () => {
         setTweetMessage('')
         setTweetImage(null)
         setErrorMessage('')
+
+        // ツイート投稿後にホーム画面1ページ目に遷移させる
+        const queryParams = new URLSearchParams(location.search)
+        if (queryParams.get('page') === null) {
+          // 元々1ページ目にいた場合はクエリパラメータがないので意図的に再取得させる
+          handleGetPosts(1)
+        } else {
+          navigate(homeUrl)
+        }
       })
       .catch((err) => {
         setErrorMessage((err.message || err) as string)
@@ -120,7 +138,6 @@ const StyledTweetBox = styled.div`
     width: 130px !important;
     height: 40px !important;
     border-radius: 30px !important;
-    /* margin-top: 20px !important; */
     margin-left: auto !important;
   }
 `

--- a/src/components/organisms/TweetBox.tsx
+++ b/src/components/organisms/TweetBox.tsx
@@ -62,7 +62,7 @@ export const TweetBox: React.FC<Props> = ({ handleGetPosts }) => {
       })
       .catch((err) => {
         setErrorMessage((err.message || err) as string)
-        console.log(err)
+        console.error(err)
       })
   }
 

--- a/src/components/organisms/TweetBox.tsx
+++ b/src/components/organisms/TweetBox.tsx
@@ -80,7 +80,6 @@ export const TweetBox: React.FC = () => {
 const StyledTweetBox = styled.div`
   .tweetBox {
     padding-bottom: 10px;
-    border-bottom: 8px solid var(--twitter-background);
     padding-right: 10px;
   }
 

--- a/src/components/organisms/TweetBox.tsx
+++ b/src/components/organisms/TweetBox.tsx
@@ -5,9 +5,18 @@ import { Button } from '@mui/material'
 
 export const TweetBox: React.FC = () => {
   const [tweetMessage, setTweetMessage] = useState('')
-  const [tweetImage, setTweetImage] = useState('')
+  const [tweetImage, setTweetImage] = useState<File | null>(null)
 
-  const sendTweet = (e: React.MouseEvent<HTMLButtonElement>) => {
+  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (file && (file.type === 'image/png' || file.type === 'image/jpeg')) {
+      setTweetImage(file)
+    } else {
+      alert('画像形式は PNG または JPEG のみ投稿できます')
+      e.target.value = ''
+    }
+  }
+
     if (tweetMessage === '') return
 
     e.preventDefault()
@@ -31,17 +40,12 @@ export const TweetBox: React.FC = () => {
             />
           </div>
           <input
-            value={tweetImage}
             className="tweetBoxImageInput"
-            placeholder="画像のURLを入力してください"
-            type="text"
-            onChange={(e) => setTweetImage(e.target.value)}
+            type="file"
+            accept="image/png, image/jpeg"
+            onChange={handleImageChange}
           />
-          <Button
-            className="tweetBoxTweetButton"
-            type="submit"
-            onClick={(e) => sendTweet(e)}
-          >
+          <Button className="tweetBoxTweetButton" type="submit">
             ツイートする
           </Button>
         </form>

--- a/src/components/organisms/TweetBox.tsx
+++ b/src/components/organisms/TweetBox.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react'
 import styled from 'styled-components'
 import { Avatar } from '@mui/material'
 import { Button } from '@mui/material'
+import { postTweet, postTweetImage } from '../../lib/api/tweet'
 
 export const TweetBox: React.FC = () => {
   const [tweetMessage, setTweetMessage] = useState('')
@@ -17,19 +18,36 @@ export const TweetBox: React.FC = () => {
     }
   }
 
+  const handlePostTweet = (e: React.FormEvent) => {
     if (tweetMessage === '') return
 
     e.preventDefault()
-    // TODO: ツイートを送信する処理
 
-    setTweetMessage('')
-    setTweetImage('')
+    postTweet(tweetMessage)
+      .then((res) => {
+        if (res.status != 200) throw new Error('ツイート投稿に失敗しました')
+        if (!!res.data.tweet || !res.data.tweet.id)
+          throw new Error('ツイートに失敗しました')
+
+        const tweetId: number = res.data.tweet.id
+        if (tweetImage) {
+          return postTweetImage(tweetId, tweetImage)
+        }
+        return Promise.resolve(res)
+      })
+      .then(() => {
+        setTweetMessage('')
+        setTweetImage(null)
+      })
+      .catch((err) => {
+        console.log(err)
+      })
   }
 
   return (
     <StyledTweetBox>
       <div className="tweetBox">
-        <form>
+        <form onSubmit={handlePostTweet}>
           <div className="tweetBoxInput">
             <Avatar />
             <input

--- a/src/components/organisms/TweetBox.tsx
+++ b/src/components/organisms/TweetBox.tsx
@@ -3,10 +3,12 @@ import styled from 'styled-components'
 import { Avatar } from '@mui/material'
 import { Button } from '@mui/material'
 import { postTweet, postTweetImage } from '../../lib/api/tweet'
+import { ErrorMessage } from './ErrorMessage'
 
 export const TweetBox: React.FC = () => {
   const [tweetMessage, setTweetMessage] = useState('')
   const [tweetImage, setTweetImage] = useState<File | null>(null)
+  const [errorMessage, setErrorMessage] = useState('')
 
   const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0]
@@ -25,9 +27,9 @@ export const TweetBox: React.FC = () => {
 
     postTweet(tweetMessage)
       .then((res) => {
-        if (res.status != 200) throw new Error('ツイート投稿に失敗しました')
-        if (!!res.data.tweet || !res.data.tweet.id)
-          throw new Error('ツイートに失敗しました')
+        if (res.status != 201) throw new Error('ツイート投稿に失敗しました')
+        if (!res.data.tweet || !res.data.tweet.id)
+          throw new Error('ツイート投稿に失敗しました')
 
         const tweetId: number = res.data.tweet.id
         if (tweetImage) {
@@ -38,8 +40,10 @@ export const TweetBox: React.FC = () => {
       .then(() => {
         setTweetMessage('')
         setTweetImage(null)
+        setErrorMessage('')
       })
       .catch((err) => {
+        setErrorMessage((err.message || err) as string)
         console.log(err)
       })
   }
@@ -67,6 +71,7 @@ export const TweetBox: React.FC = () => {
             ツイートする
           </Button>
         </form>
+        {errorMessage !== '' && <ErrorMessage>{errorMessage}</ErrorMessage>}
       </div>
     </StyledTweetBox>
   )

--- a/src/components/organisms/TweetBox.tsx
+++ b/src/components/organisms/TweetBox.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useRef, useState } from 'react'
 import styled from 'styled-components'
 import { Avatar } from '@mui/material'
 import { Button } from '@mui/material'
@@ -14,20 +14,10 @@ type Props = {
 
 export const TweetBox: React.FC<Props> = ({ handleGetPosts }) => {
   const [tweetMessage, setTweetMessage] = useState('')
-  const [tweetImage, setTweetImage] = useState<File | null>(null)
   const [errorMessage, setErrorMessage] = useState('')
 
   const navigate = useNavigate()
-
-  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0]
-    if (file && (file.type === 'image/png' || file.type === 'image/jpeg')) {
-      setTweetImage(file)
-    } else {
-      alert('画像形式は PNG または JPEG のみ投稿できます')
-      e.target.value = ''
-    }
-  }
+  const imageInputRef = useRef<HTMLInputElement>(null)
 
   const handlePostTweet = (e: React.FormEvent) => {
     if (tweetMessage === '') return
@@ -41,6 +31,7 @@ export const TweetBox: React.FC<Props> = ({ handleGetPosts }) => {
           throw new Error('ツイート投稿に失敗しました')
 
         const tweetId: number = res.data.tweet.id
+        const tweetImage = imageInputRef.current?.files?.[0]
         if (tweetImage) {
           return postTweetImage(tweetId, tweetImage)
         }
@@ -48,8 +39,12 @@ export const TweetBox: React.FC<Props> = ({ handleGetPosts }) => {
       })
       .then(() => {
         setTweetMessage('')
-        setTweetImage(null)
         setErrorMessage('')
+
+        // ツイート投稿後にツイート画像をリセットする
+        if (imageInputRef.current) {
+          imageInputRef.current.value = ''
+        }
 
         // ツイート投稿後にホーム画面1ページ目に遷移させる
         const queryParams = new URLSearchParams(location.search)
@@ -81,10 +76,10 @@ export const TweetBox: React.FC<Props> = ({ handleGetPosts }) => {
           </div>
           <div className="tweetBoxImageAndButton">
             <input
+              ref={imageInputRef}
               className="tweetBoxImageInput"
               type="file"
               accept="image/png, image/jpeg"
-              onChange={handleImageChange}
             />
             <Button className="tweetBoxTweetButton" type="submit">
               ツイートする

--- a/src/components/organisms/TweetBox.tsx
+++ b/src/components/organisms/TweetBox.tsx
@@ -1,0 +1,92 @@
+import React, { useState } from 'react'
+import styled from 'styled-components'
+import { Avatar } from '@mui/material'
+import { Button } from '@mui/material'
+
+export const TweetBox: React.FC = () => {
+  const [tweetMessage, setTweetMessage] = useState('')
+  const [tweetImage, setTweetImage] = useState('')
+
+  const sendTweet = (e: React.MouseEvent<HTMLButtonElement>) => {
+    if (tweetMessage === '') return
+
+    e.preventDefault()
+    // TODO: ツイートを送信する処理
+
+    setTweetMessage('')
+    setTweetImage('')
+  }
+
+  return (
+    <StyledTweetBox>
+      <div className="tweetBox">
+        <form>
+          <div className="tweetBoxInput">
+            <Avatar />
+            <input
+              value={tweetMessage}
+              placeholder="いまどうしてる？"
+              type="text"
+              onChange={(e) => setTweetMessage(e.target.value)}
+            />
+          </div>
+          <input
+            value={tweetImage}
+            className="tweetBoxImageInput"
+            placeholder="画像のURLを入力してください"
+            type="text"
+            onChange={(e) => setTweetImage(e.target.value)}
+          />
+          <Button
+            className="tweetBoxTweetButton"
+            type="submit"
+            onClick={(e) => sendTweet(e)}
+          >
+            ツイートする
+          </Button>
+        </form>
+      </div>
+    </StyledTweetBox>
+  )
+}
+
+const StyledTweetBox = styled.div`
+  .tweetBox {
+    padding-bottom: 10px;
+    border-bottom: 8px solid var(--twitter-background);
+    padding-right: 10px;
+  }
+
+  .tweetBox > form {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .tweetBoxInput {
+    padding: 20px;
+    display: flex;
+  }
+
+  .tweetBoxInput > input {
+    flex: 1;
+    font-size: 20px;
+    margin-left: 20px;
+    border: none;
+  }
+
+  .tweetBoxImageInput {
+    border: none;
+    padding: 20px;
+  }
+
+  .tweetBoxTweetButton {
+    background-color: var(--twitter-color) !important;
+    color: white !important;
+    font-weight: 900 !important;
+    width: 130px !important;
+    height: 40px !important;
+    border-radius: 30px !important;
+    margin-top: 20px !important;
+    margin-left: auto !important;
+  }
+`

--- a/src/components/organisms/TweetBox.tsx
+++ b/src/components/organisms/TweetBox.tsx
@@ -61,15 +61,17 @@ export const TweetBox: React.FC = () => {
               onChange={(e) => setTweetMessage(e.target.value)}
             />
           </div>
-          <input
-            className="tweetBoxImageInput"
-            type="file"
-            accept="image/png, image/jpeg"
-            onChange={handleImageChange}
-          />
-          <Button className="tweetBoxTweetButton" type="submit">
-            ツイートする
-          </Button>
+          <div className="tweetBoxImageAndButton">
+            <input
+              className="tweetBoxImageInput"
+              type="file"
+              accept="image/png, image/jpeg"
+              onChange={handleImageChange}
+            />
+            <Button className="tweetBoxTweetButton" type="submit">
+              ツイートする
+            </Button>
+          </div>
         </form>
         {errorMessage !== '' && <ErrorMessage>{errorMessage}</ErrorMessage>}
       </div>
@@ -100,6 +102,12 @@ const StyledTweetBox = styled.div`
     border: none;
   }
 
+  .tweetBoxImageAndButton {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
   .tweetBoxImageInput {
     border: none;
     padding: 20px;
@@ -112,7 +120,7 @@ const StyledTweetBox = styled.div`
     width: 130px !important;
     height: 40px !important;
     border-radius: 30px !important;
-    margin-top: 20px !important;
+    /* margin-top: 20px !important; */
     margin-left: auto !important;
   }
 `

--- a/src/components/organisms/TweetBox.tsx
+++ b/src/components/organisms/TweetBox.tsx
@@ -5,6 +5,7 @@ import { Button } from '@mui/material'
 import { postTweet, postTweetImage } from '../../lib/api/tweet'
 import { ErrorMessage } from './ErrorMessage'
 import { useNavigate } from 'react-router-dom'
+import { validateTweetMessage } from '../../validators/tweetValidator'
 
 const homeUrl = process.env.PUBLIC_URL
 
@@ -20,9 +21,13 @@ export const TweetBox: React.FC<Props> = ({ handleGetPosts }) => {
   const imageInputRef = useRef<HTMLInputElement>(null)
 
   const handlePostTweet = (e: React.FormEvent) => {
-    if (tweetMessage === '') return
-
     e.preventDefault()
+
+    const validationError = validateTweetMessage(tweetMessage)
+    if (validationError) {
+      setErrorMessage(validationError)
+      return
+    }
 
     postTweet(tweetMessage)
       .then((res) => {
@@ -67,10 +72,9 @@ export const TweetBox: React.FC<Props> = ({ handleGetPosts }) => {
         <form onSubmit={handlePostTweet}>
           <div className="tweetBoxInput">
             <Avatar />
-            <input
+            <textarea
               value={tweetMessage}
               placeholder="いまどうしてる？"
-              type="text"
               onChange={(e) => setTweetMessage(e.target.value)}
             />
           </div>
@@ -108,11 +112,14 @@ const StyledTweetBox = styled.div`
     display: flex;
   }
 
-  .tweetBoxInput > input {
+  .tweetBoxInput > textarea {
     flex: 1;
     font-size: 20px;
     margin-left: 20px;
     border: none;
+    resize: none;
+    overflow: auto;
+    min-width: 0;
   }
 
   .tweetBoxImageAndButton {

--- a/src/components/pages/Home.tsx
+++ b/src/components/pages/Home.tsx
@@ -1,5 +1,43 @@
 import React from 'react'
+import { styled } from 'styled-components'
+import { SideBar } from '../templates/SideBar'
+import { TimeLine } from '../templates/TimeLine'
 
 export const Home: React.FC = () => {
-  return <div>Home</div>
+  return (
+    <StyledHome>
+      <div className="sideBar">
+        <SideBar />
+      </div>
+      <div className="timeLine">
+        <TimeLine />
+      </div>
+    </StyledHome>
+  )
 }
+
+const StyledHome = styled.div`
+  display: flex;
+  height: 100vh;
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 0 10px;
+
+  .sideBar {
+    border-right: 1px solid var(--twitter-background);
+    min-width: 300px;
+    margin-top: 20px;
+    padding-left: 20px;
+    padding-right: 20px;
+  }
+
+  .timeLine {
+    min-width: 700px;
+    border-right: 1px solid var(--twitter-background);
+    overflow-y: scroll;
+  }
+
+  .timeLine::-webkit-scrollbar {
+    display: none;
+  }
+`

--- a/src/components/pages/Home.tsx
+++ b/src/components/pages/Home.tsx
@@ -32,7 +32,7 @@ const StyledHome = styled.div`
   }
 
   .timeLine {
-    min-width: 700px;
+    min-width: 600px;
     border-right: 1px solid var(--twitter-background);
     overflow-y: scroll;
   }

--- a/src/components/templates/SideBar.tsx
+++ b/src/components/templates/SideBar.tsx
@@ -1,0 +1,37 @@
+import React from 'react'
+import TwitterIcon from '@mui/icons-material/Twitter'
+import { Button } from '@mui/material'
+
+import styled from 'styled-components'
+import { SideBarOptionList } from '../organisms/SideBarOptionList'
+
+export const SideBar: React.FC = () => {
+  return (
+    <StyledSideBar>
+      <TwitterIcon className="sideBarTwitterIcon" />
+      <SideBarOptionList />
+      <Button variant="outlined" className="sideBarTweet" fullWidth>
+        ツイートする
+      </Button>
+    </StyledSideBar>
+  )
+}
+
+const StyledSideBar = styled.div`
+  .sideBarTwitterIcon {
+    color: var(--twitter-color);
+    font-size: 30px !important;
+    margin-left: 20px;
+    margin-bottom: 20px;
+  }
+
+  .sideBarTweet {
+    background-color: var(--twitter-color) !important;
+    color: white !important;
+    font-weight: 900 !important;
+    border: none !important;
+    border-radius: 30px !important;
+    height: 50px !important;
+    margin-top: 20px !important;
+  }
+`

--- a/src/components/templates/TimeLine.tsx
+++ b/src/components/templates/TimeLine.tsx
@@ -1,16 +1,107 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import styled from 'styled-components'
 import { TweetBox } from '../organisms/TweetBox'
 import { Posts } from '../organisms/Posts'
+import { getPosts } from '../../lib/api/tweet'
+import { useNavigate } from 'react-router-dom'
+
+type Post = {
+  id: number
+  user: {
+    id: string
+    name: string
+    nickname: string
+    avatarUrl: string
+  }
+  tweet: string
+  imageUrl: string
+  retweets: number
+  likes: number
+}
+
+// TODO: リツイート、いいね機能、アバター画像後に削除する
+const initialPost: Post = {
+  id: 1,
+  user: {
+    id: 'u1',
+    name: 'aliiiiii1',
+    nickname: 'Alice',
+    avatarUrl: '/path/to/avatar1.png',
+  },
+  tweet: 'This is a sample tweet from Alice.',
+  imageUrl: 'https://source.unsplash.com/random',
+  retweets: 5,
+  likes: 20,
+}
 
 export const TimeLine: React.FC = () => {
+  const [posts, setPosts] = useState<Post[]>([])
+  const [loading, setLoading] = useState<boolean>(false)
+  const [currentPage, setCurrentPage] = React.useState(1)
+  const [totalPages, setTotalPages] = React.useState(1)
+
+  const navigate = useNavigate()
+
+  const handleChangePage = (
+    _event: React.ChangeEvent<unknown>,
+    page: number
+  ) => {
+    setCurrentPage(page)
+    navigate({ ...location, search: `?page=${page}` })
+    handleGetPosts(page)
+  }
+
+  const handleGetPosts = (page: number) => {
+    setLoading(true)
+
+    getPosts(page)
+      .then((res) => {
+        if (res && res.data) {
+          setTotalPages((res.data.pagination.totalPages as number) || 1)
+          const resPosts: Post[] = (res.data.tweets as Post[]).map((tweet) => {
+            return {
+              ...initialPost,
+              id: tweet.id,
+              user: tweet.user,
+              tweet: tweet.tweet,
+              imageUrl: tweet.imageUrl,
+              retweets: tweet.retweets,
+              likes: tweet.likes,
+            }
+          })
+          setPosts(resPosts)
+        }
+      })
+      .catch((err) => {
+        console.error(err)
+      })
+      .finally(() => {
+        setLoading(false)
+      })
+  }
+
+  useEffect(() => {
+    //  クエリパラメータからpageを取得する
+    const queryParams = new URLSearchParams(location.search)
+    const page = Number(queryParams.get('page')) || 1
+
+    setCurrentPage(page)
+    handleGetPosts(page)
+  }, [location.search])
+
   return (
     <StyledTimeLine>
       <div className="timeLineHeader">
         <h2>ホーム</h2>
-        <TweetBox />
+        <TweetBox handleGetPosts={handleGetPosts} />
       </div>
-      <Posts />
+      <Posts
+        posts={posts}
+        loading={loading}
+        currentPage={currentPage}
+        totalPages={totalPages}
+        handleChangePage={handleChangePage}
+      />
     </StyledTimeLine>
   )
 }

--- a/src/components/templates/TimeLine.tsx
+++ b/src/components/templates/TimeLine.tsx
@@ -1,0 +1,32 @@
+import React from 'react'
+import styled from 'styled-components'
+import { TweetBox } from '../organisms/TweetBox'
+import { Posts } from '../organisms/Posts'
+
+export const TimeLine: React.FC = () => {
+  return (
+    <StyledTimeLine>
+      <div className="timeLineHeader">
+        <h2>ホーム</h2>
+      </div>
+      <TweetBox />
+      <Posts />
+    </StyledTimeLine>
+  )
+}
+
+const StyledTimeLine = styled.div`
+  .timeLineHeader {
+    position: sticky;
+    top: 0;
+    background-color: white;
+    z-index: 100;
+    border: 1px solid var(--twitter-background);
+    padding: 5px 20px;
+  }
+
+  .timeLineHeader > h2 {
+    font-size: 20px;
+    font-weight: 800;
+  }
+`

--- a/src/components/templates/TimeLine.tsx
+++ b/src/components/templates/TimeLine.tsx
@@ -8,8 +8,8 @@ export const TimeLine: React.FC = () => {
     <StyledTimeLine>
       <div className="timeLineHeader">
         <h2>ホーム</h2>
+        <TweetBox />
       </div>
-      <TweetBox />
       <Posts />
     </StyledTimeLine>
   )

--- a/src/lib/api/tweet.ts
+++ b/src/lib/api/tweet.ts
@@ -1,0 +1,5 @@
+import client from './client'
+
+export const getPosts = () => {
+  return client.get('tweets')
+}

--- a/src/lib/api/tweet.ts
+++ b/src/lib/api/tweet.ts
@@ -3,3 +3,15 @@ import client from './client'
 export const getPosts = () => {
   return client.get('tweets')
 }
+
+export const postTweet = (tweet: string) => {
+  return client.post('tweets', { tweet: tweet })
+}
+
+export const postTweetImage = (tweetId: number, image: File) => {
+  const formData = new FormData()
+  formData.append('image', image)
+  formData.append('tweet_id', tweetId.toString())
+
+  return client.post(`images`, formData)
+}

--- a/src/lib/api/tweet.ts
+++ b/src/lib/api/tweet.ts
@@ -1,7 +1,14 @@
 import client from './client'
 
-export const getPosts = () => {
-  return client.get('tweets')
+const POSTS_PER_PAGE = 10
+
+export const getPosts = (currentPage: number) => {
+  return client.get('tweets', {
+    params: {
+      limit: POSTS_PER_PAGE,
+      offset: currentPage,
+    },
+  })
 }
 
 export const postTweet = (tweet: string) => {

--- a/src/validators/tweetValidator.ts
+++ b/src/validators/tweetValidator.ts
@@ -1,0 +1,9 @@
+export const validateTweetMessage = (message: string): string => {
+  if (message.length === 0) {
+    return 'ツイートは必須です'
+  }
+  if (message.length > 200) {
+    return 'ツイートは200文字以内で入力してください'
+  }
+  return ''
+}


### PR DESCRIPTION
## 課題のリンク

* https://github.com/happiness-chain/practice/blob/main/14.2_react/003_%E8%AA%B2%E9%A1%8C.md#%E3%83%84%E3%82%A4%E3%83%BC%E3%83%88%E6%8A%95%E7%A8%BF%E6%A9%9F%E8%83%BD

## やったこと

* ホーム画面を実装しました
  * ツイート投稿
  * ツイート一覧
  * サイドバー

## やらなかったこと

* サイドバーのリンク先設定
* サイドバー下のツイートボタンからツイート投稿する
* ユーザー名の編集機能が未実装のため、通常の会員登録フローで登録したアカウントのツイートはユーザー名が表示されません。（seedで登録したユーザーは表示されます）

## 動作確認方法

### 準備
1. [会員登録画面](https://8tako8tako8.github.io/twitter_react/registration) または [ログイン画面](https://8tako8tako8.github.io/twitter_react/login)にアクセスし、ログインする
2. ログイン後、ホーム画面にリダイレクトされる

### 動作確認
* ✅ ツイート一覧が表示されること
* ✅ ツイート一覧のページネーションが機能すること
* ✅ 画像なしツイート投稿できること
* ✅ 画像ありツイート投稿できること
* ✅ ツイートが0文字の場合にバリデーションエラーが表示されること
* ✅ ツイートが200文字を超えた場合にバリデーションエラーが表示されること
 
## キャプチャ

![image](https://github.com/8tako8tako8/twitter_react/assets/65395999/36bc997a-c7b2-4a79-a434-d26b3793eb29)

## その他

なし