### PR TITLE
ツイート詳細画面を追加

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -58,7 +58,7 @@ const App: React.FC = () => {
         {/* private route */}
         <Route path={homeUrl} element={<PrivateRoute children={<Home />} />} />
         <Route
-          path={homeUrl + '/tweets/:id'}
+          path={homeUrl + '/tweets/:tweetId'}
           element={<PrivateRoute children={<PostDetail />} />}
         />
         <Route path="*" element={<Error />} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import { AppDispatch, RootState } from './redux/store'
 import { getCurrentUser } from './lib/api/auth'
 import { setCurrentUser } from './redux/userSlice'
 import { Loading } from './components/pages/Loading'
+import { PostDetail } from './components/pages/PostDetail'
 
 export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector
 export const useAppDispatch = () => useDispatch<AppDispatch>()
@@ -56,6 +57,10 @@ const App: React.FC = () => {
 
         {/* private route */}
         <Route path={homeUrl} element={<PrivateRoute children={<Home />} />} />
+        <Route
+          path={homeUrl + '/tweets/:id'}
+          element={<PrivateRoute children={<PostDetail />} />}
+        />
         <Route path="*" element={<Error />} />
       </Routes>
     </Router>

--- a/src/components/molecules/SideBarOption.tsx
+++ b/src/components/molecules/SideBarOption.tsx
@@ -1,28 +1,38 @@
 import React from 'react'
+import { Link } from 'react-router-dom'
 import styled from 'styled-components'
 
 type Props = {
   text: string
+  linkTo: string
   isActive: boolean
   children: React.ReactNode
 }
 
 export const SideBarOption: React.FC<Props> = ({
   text,
+  linkTo,
   isActive,
   children,
 }) => {
   return (
     <StyledSideBarOption>
-      <div className={`sideBarOption ${isActive && 'sideBarOptionActive'}`}>
-        {children}
-        <h2>{text}</h2>
-      </div>
+      <Link to={`${linkTo}`} className="sideBarOptionLink">
+        <div className={`sideBarOption ${isActive && 'sideBarOptionActive'}`}>
+          {children}
+          <h2>{text}</h2>
+        </div>
+      </Link>
     </StyledSideBarOption>
   )
 }
 
 const StyledSideBarOption = styled.div`
+  .sideBarOptionLink {
+    text-decoration: none;
+    color: inherit;
+  }
+
   .sideBarOption {
     display: flex;
     align-items: center;

--- a/src/components/organisms/Comment.tsx
+++ b/src/components/organisms/Comment.tsx
@@ -1,0 +1,99 @@
+import { VerifiedUser } from '@mui/icons-material'
+import { Avatar } from '@mui/material'
+import React from 'react'
+import { styled } from 'styled-components'
+
+type Comment = {
+  id: number
+  user: {
+    id: string
+    name: string
+    nickname: string
+    avatarUrl: string
+  }
+  comment: string
+  imageUrl: string
+}
+
+type Props = {
+  comment: Comment
+}
+
+export const Comment: React.FC<Props> = ({ comment }) => {
+  return (
+    <StyledComment>
+      <div className="comment">
+        <div className="commentAvatar">
+          <Avatar />
+        </div>
+        <div className="commentBody">
+          <div className="commentHeader">
+            <div className="commentHeaderText">
+              <h3>
+                {comment.user.nickname}
+                <span className="commentHeaderSpecial">
+                  <VerifiedUser className="commentBadge" />
+                  {comment.user.name}
+                </span>
+              </h3>
+            </div>
+            <div className="commentHeaderDescription">
+              <p>{comment.comment}</p>
+            </div>
+          </div>
+          {comment.imageUrl && <img src={comment.imageUrl} />}
+        </div>
+      </div>
+    </StyledComment>
+  )
+}
+
+const StyledComment = styled.div`
+  .comment {
+    display: flex;
+    align-items: flex-start;
+    border-bottom: 1px solid var(--twitter-background);
+  }
+
+  .commentBody {
+    flex: 1;
+    min-width: 0;
+  }
+
+  p {
+    margin: 0;
+    padding: 0;
+  }
+
+  .commentBody > img {
+    border-radius: 20px;
+    width: 100%;
+  }
+
+  .commentHeaderDescription {
+    margin-bottom: 10px;
+    font-size: 15px;
+    white-space: normal;
+    word-wrap: break-word;
+  }
+
+  .commentHeaderText > h3 {
+    font-size: 15px;
+    margin-bottom: 5px;
+  }
+
+  .commentBadge {
+    font-size: 14px !important;
+    color: var(--twitter-color);
+  }
+
+  .commentHeaderSpecial {
+    font-weight: 600;
+    font-size: 12px;
+    color: gray;
+  }
+
+  .commentAvatar {
+    padding: 15px;
+  }
+`

--- a/src/components/organisms/CommentBox.tsx
+++ b/src/components/organisms/CommentBox.tsx
@@ -1,0 +1,72 @@
+import { Avatar, Button } from '@mui/material'
+import React from 'react'
+import { styled } from 'styled-components'
+
+export const CommentBox: React.FC = () => {
+  const [commentMessage, setCommentMessage] = React.useState('')
+
+  const handleSendComment = (e: React.FormEvent) => {
+    e.preventDefault()
+
+    // TODO: コメント投稿処理
+  }
+
+  return (
+    <StyledCommentBox>
+      <div className="commentBox">
+        <form onSubmit={handleSendComment}>
+          <div className="commentBoxInput">
+            <Avatar />
+            <textarea
+              value={commentMessage}
+              placeholder="返信をツイート"
+              onChange={(e) => setCommentMessage(e.target.value)}
+            />
+          </div>
+          <Button className="commentBoxButton" type="submit">
+            返信
+          </Button>
+        </form>
+      </div>
+    </StyledCommentBox>
+  )
+}
+
+const StyledCommentBox = styled.div`
+  .commentBox {
+    padding-bottom: 10px;
+    padding-right: 10px;
+  }
+
+  .commentBox > form {
+    display: flex;
+    justify-content: space-between;
+  }
+
+  .commentBoxInput {
+    padding: 20px;
+    display: flex;
+    width: 80%;
+  }
+
+  .commentBoxInput > textarea {
+    flex: 1;
+    font-size: 20px;
+    margin-left: 20px;
+    border: none;
+    resize: none;
+    overflow: auto;
+    min-width: 0;
+  }
+
+  .commentBoxButton {
+    background-color: var(--twitter-color) !important;
+    color: white !important;
+    font-weight: 900 !important;
+    width: 80px !important;
+    height: 40px !important;
+    border-radius: 30px !important;
+    margin-left: auto !important;
+    margin-top: 20px !important;
+  }
+`

--- a/src/components/organisms/CommentBox.tsx
+++ b/src/components/organisms/CommentBox.tsx
@@ -36,6 +36,7 @@ const StyledCommentBox = styled.div`
   .commentBox {
     padding-bottom: 10px;
     padding-right: 10px;
+    border-bottom: 1px solid var(--twitter-background);
   }
 
   .commentBox > form {

--- a/src/components/organisms/Comments.tsx
+++ b/src/components/organisms/Comments.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { styled } from 'styled-components'
 import { Comment } from './Comment'
+import { Pagination } from '@mui/material'
 
 type Comment = {
   id: number
@@ -42,13 +43,33 @@ const initialComments: Comment[] = [
 export const Comments: React.FC = () => {
   const [comments] = React.useState<Comment[]>(initialComments)
 
+  const totalPages = 1
+  const currentPage = 1
+
   return (
     <StyledComments>
       {comments.map((comment) => (
         <Comment key={comment.id} comment={comment} />
       ))}
+      <div className="pagination">
+        <Pagination
+          count={totalPages}
+          page={currentPage}
+          variant="outlined"
+          color="primary"
+          size="small"
+        />
+      </div>
     </StyledComments>
   )
 }
 
-const StyledComments = styled.div``
+const StyledComments = styled.div`
+  .pagination {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin-top: 20px;
+    margin-bottom: 20px;
+  }
+`

--- a/src/components/organisms/Comments.tsx
+++ b/src/components/organisms/Comments.tsx
@@ -1,0 +1,54 @@
+import React from 'react'
+import { styled } from 'styled-components'
+import { Comment } from './Comment'
+
+type Comment = {
+  id: number
+  user: {
+    id: string
+    name: string
+    nickname: string
+    avatarUrl: string
+  }
+  comment: string
+  imageUrl: string
+}
+
+const initialComments: Comment[] = [
+  {
+    id: 1,
+    user: {
+      id: '1',
+      name: '山田太郎',
+      nickname: 'taro',
+      avatarUrl: '/path/to/avatar1.png',
+    },
+    comment: 'コメント1',
+    imageUrl: 'https://source.unsplash.com/random',
+  },
+  {
+    id: 2,
+    user: {
+      id: '2',
+      name: '山田二郎',
+      nickname: 'jiro',
+      avatarUrl: '/path/to/avatar1.png',
+    },
+    comment: 'コメント2',
+    imageUrl: 'https://source.unsplash.com/random',
+  },
+]
+
+export const Comments: React.FC = () => {
+  const [comments] = React.useState<Comment[]>(initialComments)
+
+  return (
+    <StyledComments>
+      {comments.map((comment) => (
+        <Comment key={comment.id} comment={comment} />
+      ))}
+    </StyledComments>
+  )
+}
+
+const StyledComments = styled.div``

--- a/src/components/organisms/Post.tsx
+++ b/src/components/organisms/Post.tsx
@@ -6,6 +6,7 @@ import {
 } from '@mui/icons-material'
 import { Avatar } from '@mui/material'
 import React from 'react'
+import { Link } from 'react-router-dom'
 import styled from 'styled-components'
 
 type Post = {
@@ -26,6 +27,8 @@ type Props = {
   post: Post
 }
 
+const homeUrl = process.env.PUBLIC_URL
+
 export const Post: React.FC<Props> = (props) => {
   const { post } = props
 
@@ -36,20 +39,22 @@ export const Post: React.FC<Props> = (props) => {
           <Avatar />
         </div>
         <div className="postBody">
-          <div className="postHeader">
-            <div className="postHeaderText">
-              <h3>
-                {post.user.nickname}
-                <span className="postHeaderSpecial">
-                  <VerifiedUser className="postBadge" />
-                  {post.user.name}
-                </span>
-              </h3>
+          <Link to={`${homeUrl}/tweets/${post.id}`} className="postLink">
+            <div className="postHeader">
+              <div className="postHeaderText">
+                <h3>
+                  {post.user.nickname}
+                  <span className="postHeaderSpecial">
+                    <VerifiedUser className="postBadge" />
+                    {post.user.name}
+                  </span>
+                </h3>
+              </div>
+              <div className="postHeaderDescription">
+                <p>{post.tweet}</p>
+              </div>
             </div>
-            <div className="postHeaderDescription">
-              <p>{post.tweet}</p>
-            </div>
-          </div>
+          </Link>
           {post.imageUrl && <img src={post.imageUrl} />}
           <div className="postFooter">
             <ChatBubbleOutline fontSize="small" />
@@ -82,6 +87,11 @@ const StyledPost = styled.div`
   .postBody > img {
     border-radius: 20px;
     width: 100%;
+  }
+
+  .postLink {
+    text-decoration: none;
+    color: inherit;
   }
 
   .postFooter {

--- a/src/components/organisms/PostDetailBox.tsx
+++ b/src/components/organisms/PostDetailBox.tsx
@@ -5,8 +5,11 @@ import {
   VerifiedUser,
 } from '@mui/icons-material'
 import { Avatar } from '@mui/material'
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { styled } from 'styled-components'
+import { getPost } from '../../lib/api/tweet'
+import { useParams } from 'react-router-dom'
+import { Loading } from '../pages/Loading'
 
 type Post = {
   id: number
@@ -38,7 +41,42 @@ const initialPost: Post = {
 }
 
 export const PostDetailBox: React.FC = () => {
-  const [post] = useState<Post>(initialPost)
+  const [post, setPost] = useState<Post>(initialPost)
+  const [loading, setLoading] = useState<boolean>(false)
+
+  const { tweetId } = useParams()
+
+  const handleGetPost = (tweetId: number) => {
+    setLoading(true)
+
+    getPost(tweetId)
+      .then((res) => {
+        if (res && res.data) {
+          const resPost: Post = {
+            ...initialPost,
+            id: res.data.id,
+            user: res.data.user,
+            tweet: res.data.tweet,
+            imageUrl: res.data.imageUrl,
+          }
+          setPost(resPost)
+        }
+      })
+      .catch((err) => {
+        console.error(err)
+      })
+      .finally(() => {
+        setLoading(false)
+      })
+  }
+
+  useEffect(() => {
+    handleGetPost(Number(tweetId))
+  }, [])
+
+  if (loading) {
+    return <Loading />
+  }
 
   return (
     <StyledPostDetailBox>

--- a/src/components/organisms/PostDetailBox.tsx
+++ b/src/components/organisms/PostDetailBox.tsx
@@ -96,7 +96,7 @@ export const PostDetailBox: React.FC = () => {
               </h3>
             </div>
             <div className="postHeaderDescription">
-              <p>ツイート内容</p>
+              <p>{post.tweet}</p>
             </div>
           </div>
           {post.imageUrl && <img src={post.imageUrl} />}

--- a/src/components/organisms/PostDetailBox.tsx
+++ b/src/components/organisms/PostDetailBox.tsx
@@ -1,0 +1,155 @@
+import {
+  ChatBubbleOutline,
+  FavoriteBorder,
+  Repeat,
+  VerifiedUser,
+} from '@mui/icons-material'
+import { Avatar } from '@mui/material'
+import React, { useState } from 'react'
+import { styled } from 'styled-components'
+
+type Post = {
+  id: number
+  user: {
+    id: string
+    name: string
+    nickname: string
+    avatarUrl: string
+  }
+  tweet: string
+  imageUrl: string
+  retweets: number
+  likes: number
+}
+
+// TODO: リツイート、いいね機能、アバター画像追加後に削除する
+const initialPost: Post = {
+  id: 1,
+  user: {
+    id: 'u1',
+    name: 'aliiiiii1',
+    nickname: 'Alice',
+    avatarUrl: '/path/to/avatar1.png',
+  },
+  tweet: 'This is a sample tweet from Alice.',
+  imageUrl: 'https://source.unsplash.com/random',
+  retweets: 5,
+  likes: 20,
+}
+
+export const PostDetailBox: React.FC = () => {
+  const [post] = useState<Post>(initialPost)
+
+  return (
+    <StyledPostDetailBox>
+      <div className="post">
+        <div className="postAvatar">
+          <Avatar />
+        </div>
+        <div className="postBody">
+          <div className="postHeader">
+            <div className="postHeaderText">
+              <h3>
+                {post.user.nickname}
+                <span className="postHeaderSpecial">
+                  <VerifiedUser className="postBadge" />
+                  {post.user.name}
+                </span>
+              </h3>
+            </div>
+            <div className="postHeaderDescription">
+              <p>ツイート内容</p>
+            </div>
+          </div>
+          {post.imageUrl && <img src={post.imageUrl} />}
+          <div className="postReaction">
+            <span>{post.retweets} 件のリツイート</span>
+            <span>{post.likes} 件のいいね</span>
+          </div>
+          <div className="postFooter">
+            <ChatBubbleOutline fontSize="small" />
+            <Repeat fontSize="small" />
+            <FavoriteBorder fontSize="small" />
+          </div>
+        </div>
+      </div>
+    </StyledPostDetailBox>
+  )
+}
+
+const StyledPostDetailBox = styled.div`
+  .PostDetailBox {
+    padding-bottom: 10px;
+    padding-right: 10px;
+    display: flex;
+    flex-direction: column;
+    padding: 20px;
+  }
+
+  .post {
+    display: flex;
+    align-items: flex-start;
+    border-bottom: 1px solid var(--twitter-background);
+  }
+
+  .postBody {
+    flex: 1;
+    min-width: 0;
+  }
+
+  p {
+    margin: 0;
+    padding: 0;
+  }
+
+  .postBody > img {
+    border-radius: 20px;
+    width: 100%;
+  }
+
+  .postReaction {
+    display: flex;
+    justify-content: flex-start;
+    margin-top: 20px;
+    margin-bottom: 20px;
+  }
+
+  .postReaction > span {
+    margin-right: 20px;
+  }
+
+  .postFooter {
+    display: flex;
+    justify-content: space-between;
+    margin-top: 10px;
+    margin-bottom: 10px;
+    margin-right: 10px;
+  }
+
+  .postHeaderDescription {
+    margin-bottom: 10px;
+    font-size: 15px;
+    white-space: normal;
+    word-wrap: break-word;
+  }
+
+  .postHeaderText > h3 {
+    font-size: 15px;
+    margin-bottom: 5px;
+  }
+
+  .postBadge {
+    font-size: 14px !important;
+    color: var(--twitter-color);
+  }
+
+  .postHeaderSpecial {
+    font-weight: 600;
+    font-size: 12px;
+    color: gray;
+  }
+
+  .postAvatar {
+    padding: 15px;
+  }
+`

--- a/src/components/organisms/SideBarOptionList.tsx
+++ b/src/components/organisms/SideBarOptionList.tsx
@@ -44,7 +44,11 @@ export const SideBarOptionList: React.FC = () => {
   return (
     <StyledSideBarOptionList>
       {SIDEBAR_LIST.map((item) => (
-        <SideBarOption text={item.text} isActive={item.isActive}>
+        <SideBarOption
+          key={item.text}
+          text={item.text}
+          isActive={item.isActive}
+        >
           <item.icon />
         </SideBarOption>
       ))}

--- a/src/components/organisms/SideBarOptionList.tsx
+++ b/src/components/organisms/SideBarOptionList.tsx
@@ -9,34 +9,46 @@ import PermIdentityIcon from '@mui/icons-material/PermIdentity'
 import MoreHorizIcon from '@mui/icons-material/MoreHoriz'
 import { useLocation } from 'react-router-dom'
 
+const homeUrl = process.env.PUBLIC_URL
+
 export const SideBarOptionList: React.FC = () => {
   const location = useLocation()
 
   const SIDEBAR_LIST = [
-    { text: 'ホーム', icon: HomeIcon, isActive: location.pathname === '/' },
+    {
+      text: 'ホーム',
+      icon: HomeIcon,
+      linkTo: `${homeUrl}/`,
+      isActive: location.pathname === '/',
+    },
     {
       text: '通知',
       icon: NotificationsNoneIcon,
+      linkTo: `${homeUrl}/notifications`,
       isActive: location.pathname === '/notifications',
     },
     {
       text: 'メッセージ',
       icon: MailOutlineIcon,
+      linkTo: `${homeUrl}/messages`,
       isActive: location.pathname === '/messages',
     },
     {
       text: 'ブックマーク',
       icon: BookmarkBorderIcon,
+      linkTo: `${homeUrl}/bookmarks`,
       isActive: location.pathname === '/bookmarks',
     },
     {
       text: 'プロフィール',
       icon: PermIdentityIcon,
+      linkTo: `${homeUrl}/profile`,
       isActive: location.pathname === '/profile',
     },
     {
       text: '退会',
       icon: MoreHorizIcon,
+      linkTo: `${homeUrl}/cancel`,
       isActive: location.pathname === '/cancel',
     },
   ]
@@ -47,6 +59,7 @@ export const SideBarOptionList: React.FC = () => {
         <SideBarOption
           key={item.text}
           text={item.text}
+          linkTo={item.linkTo}
           isActive={item.isActive}
         >
           <item.icon />

--- a/src/components/pages/PostDetail.tsx
+++ b/src/components/pages/PostDetail.tsx
@@ -1,0 +1,43 @@
+import React from 'react'
+import { styled } from 'styled-components'
+import { SideBar } from '../templates/SideBar'
+import { PostDetailBox } from '../organisms/PostDetailBox'
+
+export const PostDetail: React.FC = () => {
+  return (
+    <StyledPostDetail>
+      <div className="sideBar">
+        <SideBar />
+      </div>
+      <div className="tweet">
+        <PostDetailBox />
+      </div>
+    </StyledPostDetail>
+  )
+}
+
+const StyledPostDetail = styled.div`
+  display: flex;
+  height: 100vh;
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 0 10px;
+
+  .sideBar {
+    border-right: 1px solid var(--twitter-background);
+    min-width: 300px;
+    margin-top: 20px;
+    padding-left: 20px;
+    padding-right: 20px;
+  }
+
+  .tweet {
+    min-width: 600px;
+    border-right: 1px solid var(--twitter-background);
+    overflow-y: scroll;
+  }
+
+  .tweet::-webkit-scrollbar {
+    display: none;
+  }
+`

--- a/src/components/pages/PostDetail.tsx
+++ b/src/components/pages/PostDetail.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { styled } from 'styled-components'
 import { SideBar } from '../templates/SideBar'
 import { PostDetailBox } from '../organisms/PostDetailBox'
+import { CommentBox } from '../organisms/CommentBox'
 
 export const PostDetail: React.FC = () => {
   return (
@@ -9,8 +10,9 @@ export const PostDetail: React.FC = () => {
       <div className="sideBar">
         <SideBar />
       </div>
-      <div className="tweet">
+      <div className="post">
         <PostDetailBox />
+        <CommentBox />
       </div>
     </StyledPostDetail>
   )
@@ -31,13 +33,13 @@ const StyledPostDetail = styled.div`
     padding-right: 20px;
   }
 
-  .tweet {
+  .post {
     min-width: 600px;
     border-right: 1px solid var(--twitter-background);
     overflow-y: scroll;
   }
 
-  .tweet::-webkit-scrollbar {
+  .post::-webkit-scrollbar {
     display: none;
   }
 `

--- a/src/components/pages/PostDetail.tsx
+++ b/src/components/pages/PostDetail.tsx
@@ -3,6 +3,7 @@ import { styled } from 'styled-components'
 import { SideBar } from '../templates/SideBar'
 import { PostDetailBox } from '../organisms/PostDetailBox'
 import { CommentBox } from '../organisms/CommentBox'
+import { Comments } from '../organisms/Comments'
 
 export const PostDetail: React.FC = () => {
   return (
@@ -13,6 +14,7 @@ export const PostDetail: React.FC = () => {
       <div className="post">
         <PostDetailBox />
         <CommentBox />
+        <Comments />
       </div>
     </StyledPostDetail>
   )

--- a/src/lib/api/tweet.ts
+++ b/src/lib/api/tweet.ts
@@ -11,6 +11,10 @@ export const getPosts = (currentPage: number) => {
   })
 }
 
+export const getPost = (tweetId: number) => {
+  return client.get(`tweets/${tweetId}`)
+}
+
 export const postTweet = (tweet: string) => {
   return client.post('tweets', { tweet: tweet })
 }


### PR DESCRIPTION
## 課題のリンク

* https://github.com/happiness-chain/practice/blob/main/14.2_react/003_%E8%AA%B2%E9%A1%8C.md#%E3%83%84%E3%82%A4%E3%83%BC%E3%83%88%E8%A9%B3%E7%B4%B0

## やったこと

* ツイート詳細画面を実装しました
* サイドバーから各画面に遷移できるようにしました

## やらなかったこと

* コメント投稿機能、コメント一覧機能は別PRで対応します

## 動作確認方法

### 準備
1. [会員登録画面](https://8tako8tako8.github.io/twitter_react/registration) または [ログイン画面](https://8tako8tako8.github.io/twitter_react/login)にアクセスし、ログインする

### 動作確認
* ✅ ツイート一覧からツイート詳細に遷移できること
* ✅ ツイート詳細が表示されること

## キャプチャ

* ![image](https://github.com/8tako8tako8/twitter_react/assets/65395999/58e58f86-57ab-4562-9a47-6902016d3126)

## その他

なし