### PR TITLE
プロフィール画面にツイート削除機能を追加

### DIFF
--- a/src/components/organisms/DropDownMenu.tsx
+++ b/src/components/organisms/DropDownMenu.tsx
@@ -11,21 +11,41 @@ import styled from 'styled-components'
 
 type Props = {
   open: boolean
-  handleToggle: () => void
-  handleClose: (event: Event | React.SyntheticEvent) => void
-  handleListKeyDown: (event: React.KeyboardEvent) => void
+  setOpen: React.Dispatch<React.SetStateAction<boolean>>
   anchorRef: React.MutableRefObject<HTMLButtonElement | null>
   children: React.ReactNode
 }
 
 export const DropDownMenu: React.FC<Props> = ({
   open,
-  handleToggle,
-  handleClose,
-  handleListKeyDown,
+  setOpen,
   anchorRef,
   children,
 }) => {
+  const handleClose = (event: Event | React.SyntheticEvent) => {
+    if (
+      anchorRef.current &&
+      anchorRef.current.contains(event.target as HTMLElement)
+    ) {
+      return
+    }
+
+    setOpen(false)
+  }
+
+  const handleListKeyDown = (event: React.KeyboardEvent) => {
+    if (event.key === 'Tab') {
+      event.preventDefault()
+      setOpen(false)
+    } else if (event.key === 'Escape') {
+      setOpen(false)
+    }
+  }
+
+  const handleToggle = () => {
+    setOpen((prevOpen) => !prevOpen)
+  }
+
   return (
     <StyledDropDownMenu>
       <Button

--- a/src/components/organisms/DropDownMenu.tsx
+++ b/src/components/organisms/DropDownMenu.tsx
@@ -1,0 +1,76 @@
+import { MoreVert } from '@mui/icons-material'
+import {
+  Button,
+  ClickAwayListener,
+  Grow,
+  MenuList,
+  Paper,
+  Popper,
+} from '@mui/material'
+import styled from 'styled-components'
+
+type Props = {
+  open: boolean
+  handleToggle: () => void
+  handleClose: (event: Event | React.SyntheticEvent) => void
+  handleListKeyDown: (event: React.KeyboardEvent) => void
+  anchorRef: React.MutableRefObject<HTMLButtonElement | null>
+  children: React.ReactNode
+}
+
+export const DropDownMenu: React.FC<Props> = ({
+  open,
+  handleToggle,
+  handleClose,
+  handleListKeyDown,
+  anchorRef,
+  children,
+}) => {
+  return (
+    <StyledDropDownMenu>
+      <Button
+        ref={anchorRef}
+        id="composition-button"
+        aria-controls={open ? 'composition-menu' : undefined}
+        aria-expanded={open ? 'true' : undefined}
+        aria-haspopup="true"
+        onClick={handleToggle}
+      >
+        <MoreVert />
+      </Button>
+      <Popper
+        open={open}
+        anchorEl={anchorRef.current}
+        role={undefined}
+        placement="bottom-start"
+        transition
+        disablePortal
+      >
+        {({ TransitionProps, placement }) => (
+          <Grow
+            {...TransitionProps}
+            style={{
+              transformOrigin:
+                placement === 'bottom-start' ? 'left top' : 'left bottom',
+            }}
+          >
+            <Paper>
+              <ClickAwayListener onClickAway={handleClose}>
+                <MenuList
+                  autoFocusItem={open}
+                  id="composition-menu"
+                  aria-labelledby="composition-button"
+                  onKeyDown={handleListKeyDown}
+                >
+                  {children}
+                </MenuList>
+              </ClickAwayListener>
+            </Paper>
+          </Grow>
+        )}
+      </Popper>
+    </StyledDropDownMenu>
+  )
+}
+
+const StyledDropDownMenu = styled.div``

--- a/src/components/organisms/FlashMessage.tsx
+++ b/src/components/organisms/FlashMessage.tsx
@@ -1,0 +1,36 @@
+import { Alert, AlertColor, Snackbar } from '@mui/material'
+import styled from 'styled-components'
+
+type Props = {
+  open: boolean
+  handleCloseMessage: () => void
+  severity?: AlertColor
+  children: React.ReactNode
+}
+
+export const FlashMessage: React.FC<Props> = ({
+  open,
+  handleCloseMessage,
+  severity = 'success',
+  children,
+}) => {
+  return (
+    <StyledFlashMessage>
+      <Snackbar
+        open={open}
+        autoHideDuration={6000}
+        onClose={handleCloseMessage}
+      >
+        <Alert
+          onClose={handleCloseMessage}
+          severity={severity}
+          sx={{ width: '100%' }}
+        >
+          {children}
+        </Alert>
+      </Snackbar>
+    </StyledFlashMessage>
+  )
+}
+
+const StyledFlashMessage = styled.div``

--- a/src/components/organisms/FlashMessage.tsx
+++ b/src/components/organisms/FlashMessage.tsx
@@ -3,17 +3,28 @@ import styled from 'styled-components'
 
 type Props = {
   open: boolean
-  handleCloseMessage: () => void
+  setOpen: React.Dispatch<React.SetStateAction<boolean>>
   severity?: AlertColor
   children: React.ReactNode
 }
 
 export const FlashMessage: React.FC<Props> = ({
   open,
-  handleCloseMessage,
+  setOpen,
   severity = 'success',
   children,
 }) => {
+  const handleCloseMessage = (
+    event?: React.SyntheticEvent | Event,
+    reason?: string
+  ) => {
+    if (reason === 'clickaway') {
+      return
+    }
+
+    setOpen(false)
+  }
+
   return (
     <StyledFlashMessage>
       <Snackbar

--- a/src/components/organisms/Post.tsx
+++ b/src/components/organisms/Post.tsx
@@ -78,116 +78,114 @@ export const Post: React.FC<Props> = ({ post, myself }) => {
       >
         削除に失敗しました
       </FlashMessage>
-      <div className="post">
-        <div className="postAvatar">
+      <PostCard>
+        <PostCardAvatar>
           <Avatar />
-        </div>
-        <div className="postBody">
-          <div className="postHeader">
-            <div className="postHeaderText">
-              <PostHeaderText>
-                <h3>
-                  {post.user.nickname}
-                  <span className="postHeaderSpecial">
-                    <VerifiedUser className="postBadge" />
-                    {post.user.name}
-                  </span>
-                </h3>
-                {myself && (
-                  <DropDownMenu
-                    open={openMenu}
-                    setOpen={setOpenMenu}
-                    anchorRef={anchorRef}
-                  >
-                    <MenuItem onClick={handleDeletePost}>
-                      ツイートを削除する
-                    </MenuItem>
-                  </DropDownMenu>
-                )}
-              </PostHeaderText>
-            </div>
-            <Link to={`${homeUrl}/tweets/${post.id}`} className="postLink">
-              <div className="postHeaderDescription">
-                <p>{post.tweet}</p>
-              </div>
-            </Link>
-          </div>
-          {post.imageUrl && <img src={post.imageUrl} />}
-          <div className="postFooter">
+        </PostCardAvatar>
+        <PostCardBody>
+          <PostCardBodyTop>
+            <PostCardBodyTopContents>
+              <PostCardHeaderName>
+                {post.user.nickname}
+                <VerifiedUserBadge />
+                <AccountName>{post.user.name}</AccountName>
+              </PostCardHeaderName>
+              {myself && (
+                <DropDownMenu
+                  open={openMenu}
+                  setOpen={setOpenMenu}
+                  anchorRef={anchorRef}
+                >
+                  <MenuItem onClick={handleDeletePost}>
+                    ツイートを削除する
+                  </MenuItem>
+                </DropDownMenu>
+              )}
+            </PostCardBodyTopContents>
+            <PostLink to={`${homeUrl}/tweets/${post.id}`}>
+              <PostCardBodyDescriptionBlock>
+                <PostCardBodyDescription>{post.tweet}</PostCardBodyDescription>
+              </PostCardBodyDescriptionBlock>
+            </PostLink>
+          </PostCardBodyTop>
+          {post.imageUrl && <PostImage src={post.imageUrl} />}
+          <PostFooter>
             <ChatBubbleOutline fontSize="small" />
             <Repeat fontSize="small" />
             <FavoriteBorder fontSize="small" />
-          </div>
-        </div>
-      </div>
+          </PostFooter>
+        </PostCardBody>
+      </PostCard>
     </StyledPost>
   )
 }
 
-const StyledPost = styled.div`
-  .post {
-    display: flex;
-    align-items: flex-start;
-    border-bottom: 1px solid var(--twitter-background);
-  }
+const StyledPost = styled.div``
 
-  .postBody {
-    flex: 1;
-    min-width: 0;
-  }
-
-  p {
-    margin: 0;
-    padding: 0;
-  }
-
-  .postBody > img {
-    border-radius: 20px;
-    width: 100%;
-  }
-
-  .postLink {
-    text-decoration: none;
-    color: inherit;
-  }
-
-  .postFooter {
-    display: flex;
-    justify-content: space-between;
-    margin-top: 10px;
-    margin-bottom: 10px;
-    margin-right: 10px;
-  }
-
-  .postHeaderDescription {
-    margin-bottom: 10px;
-    font-size: 15px;
-    white-space: normal;
-    word-wrap: break-word;
-  }
-
-  .postBadge {
-    font-size: 14px !important;
-    color: var(--twitter-color);
-  }
-
-  .postHeaderSpecial {
-    font-weight: 600;
-    font-size: 12px;
-    color: gray;
-  }
-
-  .postAvatar {
-    padding: 15px;
-  }
+const PostCard = styled.div`
+  display: flex;
+  align-items: flex-start;
+  border-bottom: 1px solid var(--twitter-background);
 `
 
-const PostHeaderText = styled.div`
+const PostCardAvatar = styled.div`
+  padding: 15px;
+`
+
+const PostCardBody = styled.div`
+  flex: 1;
+  min-width: 0;
+`
+
+const PostLink = styled(Link)`
+  text-decoration: none;
+  color: inherit;
+`
+
+const PostCardBodyTop = styled.div``
+
+const PostCardBodyTopContents = styled.div`
   display: flex;
   justify-content: space-between;
+`
 
-  h3 {
-    font-size: 15px;
-    margin-bottom: 5px;
-  }
+const PostCardHeaderName = styled.h3`
+  font-size: 15px;
+  margin-bottom: 5px;
+`
+
+const AccountName = styled.span`
+  font-weight: 600;
+  font-size: 12px;
+  color: gray;
+`
+
+const VerifiedUserBadge = styled(VerifiedUser)`
+  font-size: 14px !important;
+  color: var(--twitter-color);
+`
+
+const PostCardBodyDescriptionBlock = styled.div`
+  margin-bottom: 10px;
+  font-size: 15px;
+  white-space: normal;
+  word-wrap: break-word;
+`
+
+const PostCardBodyDescription = styled.p`
+  margin: 0;
+  padding: 0;
+`
+
+const PostImage = styled.img`
+  border-radius: 20px;
+  width: 100%;
+`
+
+const PostFooter = styled.div`
+  display: flex;
+  justify-content: space-between;
+  margin-top: 10px;
+  margin-bottom: 10px;
+  margin-right: 10px;
 `

--- a/src/components/organisms/Post.tsx
+++ b/src/components/organisms/Post.tsx
@@ -15,9 +15,10 @@ import {
   Paper,
   Popper,
 } from '@mui/material'
-import React, { useRef, useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import { Link } from 'react-router-dom'
 import styled from 'styled-components'
+import { deletePost } from '../../lib/api/tweet'
 
 type Post = {
   id: number
@@ -41,14 +42,14 @@ const homeUrl = process.env.PUBLIC_URL
 
 export const Post: React.FC<Props> = (props) => {
   const { post } = props
-  const [open, setOpen] = useState(false)
+  const [openMenu, setOpenMenu] = useState(false)
   const anchorRef = useRef<HTMLButtonElement>(null)
 
   const handleToggle = () => {
-    setOpen((prevOpen) => !prevOpen)
+    setOpenMenu((prevOpen) => !prevOpen)
   }
 
-  const handleClose = (event: Event | React.SyntheticEvent) => {
+  const handleCloseMenu = (event: Event | React.SyntheticEvent) => {
     if (
       anchorRef.current &&
       anchorRef.current.contains(event.target as HTMLElement)
@@ -56,26 +57,37 @@ export const Post: React.FC<Props> = (props) => {
       return
     }
 
-    setOpen(false)
+    setOpenMenu(false)
   }
 
   function handleListKeyDown(event: React.KeyboardEvent) {
     if (event.key === 'Tab') {
       event.preventDefault()
-      setOpen(false)
+      setOpenMenu(false)
     } else if (event.key === 'Escape') {
-      setOpen(false)
+      setOpenMenu(false)
     }
   }
 
-  const prevOpen = React.useRef(open)
-  React.useEffect(() => {
-    if (prevOpen.current === true && open === false) {
+  const handleDeletePost = () => {
+    deletePost(post.id)
+      .then((res) => {
+        if (res.status != 200) throw new Error('ツイート削除に失敗しました')
+      })
+      .catch((err) => {
+        console.error(err)
+      })
+    setOpenMenu(false)
+  }
+
+  const prevOpen = useRef(openMenu)
+  useEffect(() => {
+    if (prevOpen.current === true && openMenu === false) {
       anchorRef.current!.focus()
     }
 
-    prevOpen.current = open
-  }, [open])
+    prevOpen.current = openMenu
+  }, [openMenu])
 
   return (
     <StyledPost>
@@ -99,15 +111,15 @@ export const Post: React.FC<Props> = (props) => {
                     <Button
                       ref={anchorRef}
                       id="composition-button"
-                      aria-controls={open ? 'composition-menu' : undefined}
-                      aria-expanded={open ? 'true' : undefined}
+                      aria-controls={openMenu ? 'composition-menu' : undefined}
+                      aria-expanded={openMenu ? 'true' : undefined}
                       aria-haspopup="true"
                       onClick={handleToggle}
                     >
                       <MoreVert />
                     </Button>
                     <Popper
-                      open={open}
+                      open={openMenu}
                       anchorEl={anchorRef.current}
                       role={undefined}
                       placement="bottom-start"
@@ -125,14 +137,14 @@ export const Post: React.FC<Props> = (props) => {
                           }}
                         >
                           <Paper>
-                            <ClickAwayListener onClickAway={handleClose}>
+                            <ClickAwayListener onClickAway={handleCloseMenu}>
                               <MenuList
-                                autoFocusItem={open}
+                                autoFocusItem={openMenu}
                                 id="composition-menu"
                                 aria-labelledby="composition-button"
                                 onKeyDown={handleListKeyDown}
                               >
-                                <MenuItem onClick={handleClose}>
+                                <MenuItem onClick={handleDeletePost}>
                                   ツイートを削除する
                                 </MenuItem>
                               </MenuList>

--- a/src/components/organisms/Post.tsx
+++ b/src/components/organisms/Post.tsx
@@ -1,25 +1,16 @@
 import {
   ChatBubbleOutline,
   FavoriteBorder,
-  MoreVert,
   Repeat,
   VerifiedUser,
 } from '@mui/icons-material'
-import {
-  Avatar,
-  Button,
-  ClickAwayListener,
-  Grow,
-  MenuItem,
-  MenuList,
-  Paper,
-  Popper,
-} from '@mui/material'
+import { Avatar, MenuItem } from '@mui/material'
 import React, { useEffect, useRef, useState } from 'react'
 import { Link } from 'react-router-dom'
 import styled from 'styled-components'
 import { deletePost } from '../../lib/api/tweet'
 import { FlashMessage } from './FlashMessage'
+import { DropDownMenu } from './DropDownMenu'
 
 type Post = {
   id: number
@@ -149,53 +140,17 @@ export const Post: React.FC<Props> = ({ post, myself }) => {
                   </span>
                 </h3>
                 {myself && (
-                  <div>
-                    <Button
-                      ref={anchorRef}
-                      id="composition-button"
-                      aria-controls={openMenu ? 'composition-menu' : undefined}
-                      aria-expanded={openMenu ? 'true' : undefined}
-                      aria-haspopup="true"
-                      onClick={handleToggle}
-                    >
-                      <MoreVert />
-                    </Button>
-                    <Popper
-                      open={openMenu}
-                      anchorEl={anchorRef.current}
-                      role={undefined}
-                      placement="bottom-start"
-                      transition
-                      disablePortal
-                    >
-                      {({ TransitionProps, placement }) => (
-                        <Grow
-                          {...TransitionProps}
-                          style={{
-                            transformOrigin:
-                              placement === 'bottom-start'
-                                ? 'left top'
-                                : 'left bottom',
-                          }}
-                        >
-                          <Paper>
-                            <ClickAwayListener onClickAway={handleCloseMenu}>
-                              <MenuList
-                                autoFocusItem={openMenu}
-                                id="composition-menu"
-                                aria-labelledby="composition-button"
-                                onKeyDown={handleListKeyDown}
-                              >
-                                <MenuItem onClick={handleDeletePost}>
-                                  ツイートを削除する
-                                </MenuItem>
-                              </MenuList>
-                            </ClickAwayListener>
-                          </Paper>
-                        </Grow>
-                      )}
-                    </Popper>
-                  </div>
+                  <DropDownMenu
+                    open={openMenu}
+                    handleToggle={handleToggle}
+                    handleClose={handleCloseMenu}
+                    handleListKeyDown={handleListKeyDown}
+                    anchorRef={anchorRef}
+                  >
+                    <MenuItem onClick={handleDeletePost}>
+                      ツイートを削除する
+                    </MenuItem>
+                  </DropDownMenu>
                 )}
               </PostHeaderText>
             </div>

--- a/src/components/organisms/Post.tsx
+++ b/src/components/organisms/Post.tsx
@@ -1,11 +1,21 @@
 import {
   ChatBubbleOutline,
   FavoriteBorder,
+  MoreVert,
   Repeat,
   VerifiedUser,
 } from '@mui/icons-material'
-import { Avatar } from '@mui/material'
-import React from 'react'
+import {
+  Avatar,
+  Button,
+  ClickAwayListener,
+  Grow,
+  MenuItem,
+  MenuList,
+  Paper,
+  Popper,
+} from '@mui/material'
+import React, { useRef, useState } from 'react'
 import { Link } from 'react-router-dom'
 import styled from 'styled-components'
 
@@ -31,6 +41,41 @@ const homeUrl = process.env.PUBLIC_URL
 
 export const Post: React.FC<Props> = (props) => {
   const { post } = props
+  const [open, setOpen] = useState(false)
+  const anchorRef = useRef<HTMLButtonElement>(null)
+
+  const handleToggle = () => {
+    setOpen((prevOpen) => !prevOpen)
+  }
+
+  const handleClose = (event: Event | React.SyntheticEvent) => {
+    if (
+      anchorRef.current &&
+      anchorRef.current.contains(event.target as HTMLElement)
+    ) {
+      return
+    }
+
+    setOpen(false)
+  }
+
+  function handleListKeyDown(event: React.KeyboardEvent) {
+    if (event.key === 'Tab') {
+      event.preventDefault()
+      setOpen(false)
+    } else if (event.key === 'Escape') {
+      setOpen(false)
+    }
+  }
+
+  const prevOpen = React.useRef(open)
+  React.useEffect(() => {
+    if (prevOpen.current === true && open === false) {
+      anchorRef.current!.focus()
+    }
+
+    prevOpen.current = open
+  }, [open])
 
   return (
     <StyledPost>
@@ -39,9 +84,9 @@ export const Post: React.FC<Props> = (props) => {
           <Avatar />
         </div>
         <div className="postBody">
-          <Link to={`${homeUrl}/tweets/${post.id}`} className="postLink">
-            <div className="postHeader">
-              <div className="postHeaderText">
+          <div className="postHeader">
+            <div className="postHeaderText">
+              <PostHeaderText>
                 <h3>
                   {post.user.nickname}
                   <span className="postHeaderSpecial">
@@ -49,12 +94,63 @@ export const Post: React.FC<Props> = (props) => {
                     {post.user.name}
                   </span>
                 </h3>
-              </div>
+                {true && (
+                  <div>
+                    <Button
+                      ref={anchorRef}
+                      id="composition-button"
+                      aria-controls={open ? 'composition-menu' : undefined}
+                      aria-expanded={open ? 'true' : undefined}
+                      aria-haspopup="true"
+                      onClick={handleToggle}
+                    >
+                      <MoreVert />
+                    </Button>
+                    <Popper
+                      open={open}
+                      anchorEl={anchorRef.current}
+                      role={undefined}
+                      placement="bottom-start"
+                      transition
+                      disablePortal
+                    >
+                      {({ TransitionProps, placement }) => (
+                        <Grow
+                          {...TransitionProps}
+                          style={{
+                            transformOrigin:
+                              placement === 'bottom-start'
+                                ? 'left top'
+                                : 'left bottom',
+                          }}
+                        >
+                          <Paper>
+                            <ClickAwayListener onClickAway={handleClose}>
+                              <MenuList
+                                autoFocusItem={open}
+                                id="composition-menu"
+                                aria-labelledby="composition-button"
+                                onKeyDown={handleListKeyDown}
+                              >
+                                <MenuItem onClick={handleClose}>
+                                  ツイートを削除する
+                                </MenuItem>
+                              </MenuList>
+                            </ClickAwayListener>
+                          </Paper>
+                        </Grow>
+                      )}
+                    </Popper>
+                  </div>
+                )}
+              </PostHeaderText>
+            </div>
+            <Link to={`${homeUrl}/tweets/${post.id}`} className="postLink">
               <div className="postHeaderDescription">
                 <p>{post.tweet}</p>
               </div>
-            </div>
-          </Link>
+            </Link>
+          </div>
           {post.imageUrl && <img src={post.imageUrl} />}
           <div className="postFooter">
             <ChatBubbleOutline fontSize="small" />
@@ -109,11 +205,6 @@ const StyledPost = styled.div`
     word-wrap: break-word;
   }
 
-  .postHeaderText > h3 {
-    font-size: 15px;
-    margin-bottom: 5px;
-  }
-
   .postBadge {
     font-size: 14px !important;
     color: var(--twitter-color);
@@ -127,5 +218,15 @@ const StyledPost = styled.div`
 
   .postAvatar {
     padding: 15px;
+  }
+`
+
+const PostHeaderText = styled.div`
+  display: flex;
+  justify-content: space-between;
+
+  h3 {
+    font-size: 15px;
+    margin-bottom: 5px;
   }
 `

--- a/src/components/organisms/Post.tsx
+++ b/src/components/organisms/Post.tsx
@@ -6,7 +6,6 @@ import {
   VerifiedUser,
 } from '@mui/icons-material'
 import {
-  Alert,
   Avatar,
   Button,
   ClickAwayListener,
@@ -15,12 +14,12 @@ import {
   MenuList,
   Paper,
   Popper,
-  Snackbar,
 } from '@mui/material'
 import React, { useEffect, useRef, useState } from 'react'
 import { Link } from 'react-router-dom'
 import styled from 'styled-components'
 import { deletePost } from '../../lib/api/tweet'
+import { FlashMessage } from './FlashMessage'
 
 type Post = {
   id: number
@@ -48,8 +47,6 @@ export const Post: React.FC<Props> = ({ post, myself }) => {
   const [openSuccessMessage, setOpenSuccessMessage] = useState(false)
   const [openErrorMessage, setOpenErrorMessage] = useState(false)
   const anchorRef = useRef<HTMLButtonElement>(null)
-
-  const isDeleteable = true
 
   const handleToggle = () => {
     setOpenMenu((prevOpen) => !prevOpen)
@@ -122,36 +119,20 @@ export const Post: React.FC<Props> = ({ post, myself }) => {
 
   return (
     <StyledPost>
-      {myself && (
-        <>
-          <Snackbar
-            open={openSuccessMessage}
-            autoHideDuration={6000}
-            onClose={handleCloseSuccessMessage}
-          >
-            <Alert
-              onClose={handleCloseSuccessMessage}
-              severity="success"
-              sx={{ width: '100%' }}
-            >
-              ツイートを削除しました
-            </Alert>
-          </Snackbar>
-          <Snackbar
-            open={openErrorMessage}
-            autoHideDuration={6000}
-            onClose={handleCloseErrorMessage}
-          >
-            <Alert
-              onClose={handleCloseErrorMessage}
-              severity="error"
-              sx={{ width: '100%' }}
-            >
-              ツイートの削除に失敗しました
-            </Alert>
-          </Snackbar>
-        </>
-      )}
+      <FlashMessage
+        open={openSuccessMessage}
+        handleCloseMessage={handleCloseSuccessMessage}
+        severity="success"
+      >
+        削除しました
+      </FlashMessage>
+      <FlashMessage
+        open={openErrorMessage}
+        handleCloseMessage={handleCloseErrorMessage}
+        severity="error"
+      >
+        削除に失敗しました
+      </FlashMessage>
       <div className="post">
         <div className="postAvatar">
           <Avatar />
@@ -167,7 +148,7 @@ export const Post: React.FC<Props> = ({ post, myself }) => {
                     {post.user.name}
                   </span>
                 </h3>
-                {isDeleteable && (
+                {myself && (
                   <div>
                     <Button
                       ref={anchorRef}

--- a/src/components/organisms/Post.tsx
+++ b/src/components/organisms/Post.tsx
@@ -6,6 +6,7 @@ import {
   VerifiedUser,
 } from '@mui/icons-material'
 import {
+  Alert,
   Avatar,
   Button,
   ClickAwayListener,
@@ -14,6 +15,7 @@ import {
   MenuList,
   Paper,
   Popper,
+  Snackbar,
 } from '@mui/material'
 import React, { useEffect, useRef, useState } from 'react'
 import { Link } from 'react-router-dom'
@@ -43,6 +45,8 @@ const homeUrl = process.env.PUBLIC_URL
 export const Post: React.FC<Props> = (props) => {
   const { post } = props
   const [openMenu, setOpenMenu] = useState(false)
+  const [openSuccessMessage, setOpenSuccessMessage] = useState(false)
+  const [openErrorMessage, setOpenErrorMessage] = useState(false)
   const anchorRef = useRef<HTMLButtonElement>(null)
 
   const handleToggle = () => {
@@ -60,6 +64,28 @@ export const Post: React.FC<Props> = (props) => {
     setOpenMenu(false)
   }
 
+  const handleCloseSuccessMessage = (
+    event?: React.SyntheticEvent | Event,
+    reason?: string
+  ) => {
+    if (reason === 'clickaway') {
+      return
+    }
+
+    setOpenSuccessMessage(false)
+  }
+
+  const handleCloseErrorMessage = (
+    event?: React.SyntheticEvent | Event,
+    reason?: string
+  ) => {
+    if (reason === 'clickaway') {
+      return
+    }
+
+    setOpenErrorMessage(false)
+  }
+
   function handleListKeyDown(event: React.KeyboardEvent) {
     if (event.key === 'Tab') {
       event.preventDefault()
@@ -73,9 +99,12 @@ export const Post: React.FC<Props> = (props) => {
     deletePost(post.id)
       .then((res) => {
         if (res.status != 200) throw new Error('ツイート削除に失敗しました')
+
+        setOpenSuccessMessage(true)
       })
       .catch((err) => {
         console.error(err)
+        setOpenErrorMessage(true)
       })
     setOpenMenu(false)
   }
@@ -91,6 +120,32 @@ export const Post: React.FC<Props> = (props) => {
 
   return (
     <StyledPost>
+      <Snackbar
+        open={openSuccessMessage}
+        autoHideDuration={6000}
+        onClose={handleCloseSuccessMessage}
+      >
+        <Alert
+          onClose={handleCloseSuccessMessage}
+          severity="success"
+          sx={{ width: '100%' }}
+        >
+          ツイートを削除しました
+        </Alert>
+      </Snackbar>
+      <Snackbar
+        open={openErrorMessage}
+        autoHideDuration={6000}
+        onClose={handleCloseErrorMessage}
+      >
+        <Alert
+          onClose={handleCloseErrorMessage}
+          severity="error"
+          sx={{ width: '100%' }}
+        >
+          ツイートの削除に失敗しました
+        </Alert>
+      </Snackbar>
       <div className="post">
         <div className="postAvatar">
           <Avatar />

--- a/src/components/organisms/Post.tsx
+++ b/src/components/organisms/Post.tsx
@@ -29,11 +29,12 @@ type Post = {
 type Props = {
   post: Post
   myself: boolean
+  handleGetProfile?: (userId: number) => void
 }
 
 const homeUrl = process.env.PUBLIC_URL
 
-export const Post: React.FC<Props> = ({ post, myself }) => {
+export const Post: React.FC<Props> = ({ post, myself, handleGetProfile }) => {
   const [openMenu, setOpenMenu] = useState(false)
   const [openSuccessMessage, setOpenSuccessMessage] = useState(false)
   const [openErrorMessage, setOpenErrorMessage] = useState(false)
@@ -45,6 +46,7 @@ export const Post: React.FC<Props> = ({ post, myself }) => {
         if (res.status != 200) throw new Error('ツイート削除に失敗しました')
 
         setOpenSuccessMessage(true)
+        if (handleGetProfile) handleGetProfile(Number(post.user.id))
       })
       .catch((err) => {
         console.error(err)

--- a/src/components/organisms/Post.tsx
+++ b/src/components/organisms/Post.tsx
@@ -39,28 +39,6 @@ export const Post: React.FC<Props> = ({ post, myself }) => {
   const [openErrorMessage, setOpenErrorMessage] = useState(false)
   const anchorRef = useRef<HTMLButtonElement>(null)
 
-  const handleCloseSuccessMessage = (
-    event?: React.SyntheticEvent | Event,
-    reason?: string
-  ) => {
-    if (reason === 'clickaway') {
-      return
-    }
-
-    setOpenSuccessMessage(false)
-  }
-
-  const handleCloseErrorMessage = (
-    event?: React.SyntheticEvent | Event,
-    reason?: string
-  ) => {
-    if (reason === 'clickaway') {
-      return
-    }
-
-    setOpenErrorMessage(false)
-  }
-
   const handleDeletePost = () => {
     deletePost(post.id)
       .then((res) => {
@@ -88,14 +66,14 @@ export const Post: React.FC<Props> = ({ post, myself }) => {
     <StyledPost>
       <FlashMessage
         open={openSuccessMessage}
-        handleCloseMessage={handleCloseSuccessMessage}
+        setOpen={setOpenSuccessMessage}
         severity="success"
       >
         削除しました
       </FlashMessage>
       <FlashMessage
         open={openErrorMessage}
-        handleCloseMessage={handleCloseErrorMessage}
+        setOpen={setOpenErrorMessage}
         severity="error"
       >
         削除に失敗しました

--- a/src/components/organisms/Post.tsx
+++ b/src/components/organisms/Post.tsx
@@ -38,16 +38,18 @@ type Post = {
 
 type Props = {
   post: Post
+  myself: boolean
 }
 
 const homeUrl = process.env.PUBLIC_URL
 
-export const Post: React.FC<Props> = (props) => {
-  const { post } = props
+export const Post: React.FC<Props> = ({ post, myself }) => {
   const [openMenu, setOpenMenu] = useState(false)
   const [openSuccessMessage, setOpenSuccessMessage] = useState(false)
   const [openErrorMessage, setOpenErrorMessage] = useState(false)
   const anchorRef = useRef<HTMLButtonElement>(null)
+
+  const isDeleteable = true
 
   const handleToggle = () => {
     setOpenMenu((prevOpen) => !prevOpen)
@@ -120,32 +122,36 @@ export const Post: React.FC<Props> = (props) => {
 
   return (
     <StyledPost>
-      <Snackbar
-        open={openSuccessMessage}
-        autoHideDuration={6000}
-        onClose={handleCloseSuccessMessage}
-      >
-        <Alert
-          onClose={handleCloseSuccessMessage}
-          severity="success"
-          sx={{ width: '100%' }}
-        >
-          ツイートを削除しました
-        </Alert>
-      </Snackbar>
-      <Snackbar
-        open={openErrorMessage}
-        autoHideDuration={6000}
-        onClose={handleCloseErrorMessage}
-      >
-        <Alert
-          onClose={handleCloseErrorMessage}
-          severity="error"
-          sx={{ width: '100%' }}
-        >
-          ツイートの削除に失敗しました
-        </Alert>
-      </Snackbar>
+      {myself && (
+        <>
+          <Snackbar
+            open={openSuccessMessage}
+            autoHideDuration={6000}
+            onClose={handleCloseSuccessMessage}
+          >
+            <Alert
+              onClose={handleCloseSuccessMessage}
+              severity="success"
+              sx={{ width: '100%' }}
+            >
+              ツイートを削除しました
+            </Alert>
+          </Snackbar>
+          <Snackbar
+            open={openErrorMessage}
+            autoHideDuration={6000}
+            onClose={handleCloseErrorMessage}
+          >
+            <Alert
+              onClose={handleCloseErrorMessage}
+              severity="error"
+              sx={{ width: '100%' }}
+            >
+              ツイートの削除に失敗しました
+            </Alert>
+          </Snackbar>
+        </>
+      )}
       <div className="post">
         <div className="postAvatar">
           <Avatar />
@@ -161,7 +167,7 @@ export const Post: React.FC<Props> = (props) => {
                     {post.user.name}
                   </span>
                 </h3>
-                {true && (
+                {isDeleteable && (
                   <div>
                     <Button
                       ref={anchorRef}

--- a/src/components/organisms/Post.tsx
+++ b/src/components/organisms/Post.tsx
@@ -39,21 +39,6 @@ export const Post: React.FC<Props> = ({ post, myself }) => {
   const [openErrorMessage, setOpenErrorMessage] = useState(false)
   const anchorRef = useRef<HTMLButtonElement>(null)
 
-  const handleToggle = () => {
-    setOpenMenu((prevOpen) => !prevOpen)
-  }
-
-  const handleCloseMenu = (event: Event | React.SyntheticEvent) => {
-    if (
-      anchorRef.current &&
-      anchorRef.current.contains(event.target as HTMLElement)
-    ) {
-      return
-    }
-
-    setOpenMenu(false)
-  }
-
   const handleCloseSuccessMessage = (
     event?: React.SyntheticEvent | Event,
     reason?: string
@@ -74,15 +59,6 @@ export const Post: React.FC<Props> = ({ post, myself }) => {
     }
 
     setOpenErrorMessage(false)
-  }
-
-  function handleListKeyDown(event: React.KeyboardEvent) {
-    if (event.key === 'Tab') {
-      event.preventDefault()
-      setOpenMenu(false)
-    } else if (event.key === 'Escape') {
-      setOpenMenu(false)
-    }
   }
 
   const handleDeletePost = () => {
@@ -142,9 +118,7 @@ export const Post: React.FC<Props> = ({ post, myself }) => {
                 {myself && (
                   <DropDownMenu
                     open={openMenu}
-                    handleToggle={handleToggle}
-                    handleClose={handleCloseMenu}
-                    handleListKeyDown={handleListKeyDown}
+                    setOpen={setOpenMenu}
                     anchorRef={anchorRef}
                   >
                     <MenuItem onClick={handleDeletePost}>

--- a/src/components/organisms/Posts.tsx
+++ b/src/components/organisms/Posts.tsx
@@ -40,7 +40,7 @@ export const Posts: React.FC<Props> = ({
   return (
     <StyledPost>
       {posts.map((post) => (
-        <Post key={post.id} post={post} />
+        <Post key={post.id} post={post} myself={false} />
       ))}
       <div className="pagination">
         <Pagination

--- a/src/components/organisms/ProfileDetail.tsx
+++ b/src/components/organisms/ProfileDetail.tsx
@@ -50,8 +50,6 @@ export const ProfileDetail: React.FC<Props> = ({
 }) => {
   const [isModalOpen, setModalOpen] = useState(false)
 
-  // const myUserId = useAppSelector((state) => state.user.userInfo?.id)
-
   const toggleModal = () => {
     setModalOpen(!isModalOpen)
   }

--- a/src/components/organisms/ProfileDetail.tsx
+++ b/src/components/organisms/ProfileDetail.tsx
@@ -5,7 +5,6 @@ import { Button } from '@mui/material'
 import React, { useState } from 'react'
 import { styled } from 'styled-components'
 import { ProfileDetailModal } from './ProfileDetailModal'
-import { useAppSelector } from '../../App'
 import { ProfileSubInfo } from './ProfileSubInfo'
 
 type User = {
@@ -41,12 +40,17 @@ type Profile = User & {
 type Props = {
   profile: Profile
   setProfile: React.Dispatch<React.SetStateAction<Profile>>
+  myself: boolean
 }
 
-export const ProfileDetail: React.FC<Props> = ({ profile, setProfile }) => {
+export const ProfileDetail: React.FC<Props> = ({
+  profile,
+  setProfile,
+  myself,
+}) => {
   const [isModalOpen, setModalOpen] = useState(false)
 
-  const myUserId = useAppSelector((state) => state.user.userInfo?.id)
+  // const myUserId = useAppSelector((state) => state.user.userInfo?.id)
 
   const toggleModal = () => {
     setModalOpen(!isModalOpen)
@@ -92,7 +96,7 @@ export const ProfileDetail: React.FC<Props> = ({ profile, setProfile }) => {
                 <img src={`${process.env.PUBLIC_URL}/no_image.png`} />
               )}
             </div>
-            {myUserId === profile.id && (
+            {myself && (
               <Button
                 className="profileBodyTopEditButton"
                 onClick={toggleModal}

--- a/src/components/organisms/VariousPosts.tsx
+++ b/src/components/organisms/VariousPosts.tsx
@@ -20,9 +20,14 @@ type Post = {
 type Props = {
   posts: Post[]
   myself: boolean
+  handleGetProfile: (userId: number) => void
 }
 
-export const VariousPosts: React.FC<Props> = ({ posts, myself }) => {
+export const VariousPosts: React.FC<Props> = ({
+  posts,
+  myself,
+  handleGetProfile,
+}) => {
   const [currentTabIndex, setCurrentTabIndex] = useState(0)
 
   const handleTabChange = (_event: React.SyntheticEvent, tabIndex: number) => {
@@ -42,7 +47,14 @@ export const VariousPosts: React.FC<Props> = ({ posts, myself }) => {
         <Tab label="いいね" />
       </Tabs>
       {currentTabIndex === 0 &&
-        posts.map((post) => <Post key={post.id} post={post} myself={myself} />)}
+        posts.map((post) => (
+          <Post
+            key={post.id}
+            post={post}
+            myself={myself}
+            handleGetProfile={handleGetProfile}
+          />
+        ))}
     </StyledVariousPosts>
   )
 }

--- a/src/components/organisms/VariousPosts.tsx
+++ b/src/components/organisms/VariousPosts.tsx
@@ -19,9 +19,10 @@ type Post = {
 
 type Props = {
   posts: Post[]
+  myself: boolean
 }
 
-export const VariousPosts: React.FC<Props> = ({ posts }) => {
+export const VariousPosts: React.FC<Props> = ({ posts, myself }) => {
   const [currentTabIndex, setCurrentTabIndex] = useState(0)
 
   const handleTabChange = (_event: React.SyntheticEvent, tabIndex: number) => {
@@ -41,7 +42,7 @@ export const VariousPosts: React.FC<Props> = ({ posts }) => {
         <Tab label="いいね" />
       </Tabs>
       {currentTabIndex === 0 &&
-        posts.map((post) => <Post key={post.id} post={post} />)}
+        posts.map((post) => <Post key={post.id} post={post} myself={myself} />)}
     </StyledVariousPosts>
   )
 }

--- a/src/components/pages/Profile.tsx
+++ b/src/components/pages/Profile.tsx
@@ -5,6 +5,7 @@ import { ProfileDetail } from '../organisms/ProfileDetail'
 import { VariousPosts } from '../organisms/VariousPosts'
 import { useParams } from 'react-router-dom'
 import { getProfile } from '../../lib/api/profile'
+import { useAppSelector } from '../../App'
 
 type User = {
   id: number
@@ -69,6 +70,8 @@ export const Profile: React.FC = () => {
   const [posts, setPosts] = useState<Post[]>([])
 
   const { userId } = useParams()
+  const myUserId = useAppSelector((state) => state.user.userInfo?.id)
+  const myself = userId === myUserId?.toString()
 
   const handleGetProfile = (userId: number) => {
     getProfile(userId)
@@ -128,8 +131,12 @@ export const Profile: React.FC = () => {
         <SideBar />
       </div>
       <div className="profile">
-        <ProfileDetail profile={profile} setProfile={setProfile} />
-        <VariousPosts posts={posts} />
+        <ProfileDetail
+          profile={profile}
+          setProfile={setProfile}
+          myself={myself}
+        />
+        <VariousPosts posts={posts} myself={myself} />
       </div>
     </StyledHome>
   )

--- a/src/components/pages/Profile.tsx
+++ b/src/components/pages/Profile.tsx
@@ -136,7 +136,11 @@ export const Profile: React.FC = () => {
           setProfile={setProfile}
           myself={myself}
         />
-        <VariousPosts posts={posts} myself={myself} />
+        <VariousPosts
+          posts={posts}
+          myself={myself}
+          handleGetProfile={handleGetProfile}
+        />
       </div>
     </StyledHome>
   )

--- a/src/lib/api/tweet.ts
+++ b/src/lib/api/tweet.ts
@@ -26,3 +26,7 @@ export const postTweetImage = (tweetId: number, image: File) => {
 
   return client.post(`images`, formData)
 }
+
+export const deletePost = (tweetId: number) => {
+  return client.delete(`tweets/${tweetId}`)
+}


### PR DESCRIPTION
## 課題のリンク

* https://github.com/happiness-chain/practice/blob/main/14.2_react/003_%E8%AA%B2%E9%A1%8C.md#%E3%83%84%E3%82%A4%E3%83%BC%E3%83%88%E5%89%8A%E9%99%A4%E6%A9%9F%E8%83%BD

## やったこと

* プロフィール画面にツイート削除機能を実装しました

## やらなかったこと

* ホーム画面のツイート一覧、ツイート詳細からのツイート削除

## 動作確認方法

### 準備
1. [会員登録画面](https://8tako8tako8.github.io/twitter_react/registration) または [ログイン画面](https://8tako8tako8.github.io/twitter_react/login)にアクセスし、ログインする
2. サイドバーからプロフィール画面に遷移する

### 動作確認
* ✅ ユーザー本人の場合、ツイートを削除できること
* ✅ ユーザー本人でない場合、ツイートを削除でき **ない** こと
  * アバターアイコンからプロフィール画面に遷移できないので、確認するならURLから直接遷移必要です

**注意事項**
<img width="500" alt="注意事項：ツイートできないボタン" src="https://github.com/8tako8tako8/twitter_react/assets/65395999/9c1c473a-e440-4b60-a169-15fccfa1bda8">

## キャプチャ

* ユーザー本人の場合
  * ![Kapture 2023-10-09 at 20 19 11](https://github.com/8tako8tako8/twitter_react/assets/65395999/77d69652-4a05-42ff-96c3-6a8ce1c5a29d)

* ユーザー本人でない場合
  * <img width="612" alt="React_App" src="https://github.com/8tako8tako8/twitter_react/assets/65395999/e58d552f-d9ef-4aa9-bc20-dc570602bbea">

## その他

なし