### PR TITLE
コメント投稿機能を追加

### DIFF
--- a/src/components/organisms/CommentBox.tsx
+++ b/src/components/organisms/CommentBox.tsx
@@ -1,14 +1,26 @@
 import { Avatar, Button } from '@mui/material'
-import React from 'react'
+import React, { useState } from 'react'
 import { styled } from 'styled-components'
+import { postComment } from '../../lib/api/comment'
+import { useParams } from 'react-router-dom'
 
 export const CommentBox: React.FC = () => {
-  const [commentMessage, setCommentMessage] = React.useState('')
+  const [commentMessage, setCommentMessage] = useState('')
+
+  const { tweetId } = useParams()
 
   const handleSendComment = (e: React.FormEvent) => {
     e.preventDefault()
 
-    // TODO: コメント投稿処理
+    postComment(commentMessage, Number(tweetId))
+      .then((res) => {
+        if (res.status != 201) throw new Error('コメント投稿に失敗しました')
+
+        setCommentMessage('')
+      })
+      .catch((err) => {
+        console.error(err)
+      })
   }
 
   return (
@@ -19,12 +31,12 @@ export const CommentBox: React.FC = () => {
             <Avatar />
             <textarea
               value={commentMessage}
-              placeholder="返信をツイート"
+              placeholder="コメントを投稿"
               onChange={(e) => setCommentMessage(e.target.value)}
             />
           </div>
           <Button className="commentBoxButton" type="submit">
-            返信
+            コメント
           </Button>
         </form>
       </div>

--- a/src/components/organisms/CommentBox.tsx
+++ b/src/components/organisms/CommentBox.tsx
@@ -29,6 +29,7 @@ export const CommentBox: React.FC = () => {
 
         setOpenSuccessMessage(true)
         setCommentMessage('')
+        setErrorMessage('')
       })
       .catch((err) => {
         setErrorMessage((err.message || err) as string)

--- a/src/components/organisms/CommentBox.tsx
+++ b/src/components/organisms/CommentBox.tsx
@@ -45,62 +45,62 @@ export const CommentBox: React.FC = () => {
       >
         コメント投稿しました
       </FlashMessage>
-      <div className="commentBox">
-        <form onSubmit={handleSendComment}>
-          <div className="commentBoxInput">
+      <CommentCard>
+        <CommentForm onSubmit={handleSendComment}>
+          <CommentInputBlock>
             <Avatar />
-            <textarea
+            <CommentTextArea
               value={commentMessage}
               placeholder="コメントを投稿"
               onChange={(e) => setCommentMessage(e.target.value)}
             />
-          </div>
-          <Button className="commentBoxButton" type="submit">
+          </CommentInputBlock>
+          <CommentButton className="commentBoxButton" type="submit">
             コメント
-          </Button>
-        </form>
-        {errorMessage !== '' && <ErrorMessage>{errorMessage}</ErrorMessage>}
-      </div>
+          </CommentButton>
+        </CommentForm>
+      </CommentCard>
+      {errorMessage !== '' && <ErrorMessage>{errorMessage}</ErrorMessage>}
     </StyledCommentBox>
   )
 }
 
-const StyledCommentBox = styled.div`
-  .commentBox {
-    padding-bottom: 10px;
-    padding-right: 10px;
-    border-bottom: 1px solid var(--twitter-background);
-  }
+const StyledCommentBox = styled.div``
 
-  .commentBox > form {
-    display: flex;
-    justify-content: space-between;
-  }
+const CommentCard = styled.div`
+  padding-bottom: 10px;
+  padding-right: 10px;
+  border-bottom: 1px solid var(--twitter-background);
+`
 
-  .commentBoxInput {
-    padding: 20px;
-    display: flex;
-    width: 80%;
-  }
+const CommentForm = styled.form`
+  display: flex;
+  justify-content: space-between;
+`
 
-  .commentBoxInput > textarea {
-    flex: 1;
-    font-size: 20px;
-    margin-left: 20px;
-    border: none;
-    resize: none;
-    overflow: auto;
-    min-width: 0;
-  }
+const CommentInputBlock = styled.div`
+  padding: 20px;
+  display: flex;
+  width: 80%;
+`
 
-  .commentBoxButton {
-    background-color: var(--twitter-color) !important;
-    color: white !important;
-    font-weight: 900 !important;
-    width: 80px !important;
-    height: 40px !important;
-    border-radius: 30px !important;
-    margin-left: auto !important;
-    margin-top: 20px !important;
-  }
+const CommentTextArea = styled.textarea`
+  flex: 1;
+  font-size: 20px;
+  margin-left: 20px;
+  border: none;
+  resize: none;
+  overflow: auto;
+  min-width: 0;
+`
+
+const CommentButton = styled(Button)`
+  background-color: var(--twitter-color) !important;
+  color: white !important;
+  font-weight: 900 !important;
+  width: 80px !important;
+  height: 40px !important;
+  border-radius: 30px !important;
+  margin-left: auto !important;
+  margin-top: 20px !important;
 `

--- a/src/lib/api/comment.ts
+++ b/src/lib/api/comment.ts
@@ -1,0 +1,5 @@
+import client from './client'
+
+export const postComment = (comment: string, tweetId: number) => {
+  return client.post('comments', { comment: comment, tweet_id: tweetId })
+}

--- a/src/lib/api/comment.ts
+++ b/src/lib/api/comment.ts
@@ -1,5 +1,5 @@
 import client from './client'
 
 export const postComment = (comment: string, tweetId: number) => {
-  return client.post('comments', { comment: comment, tweet_id: tweetId })
+  return client.post('comments', { comment, tweet_id: tweetId })
 }

--- a/src/validators/commentValidator.ts
+++ b/src/validators/commentValidator.ts
@@ -1,0 +1,9 @@
+export const validateCommentMessage = (message: string): string => {
+  if (message.length === 0) {
+    return 'コメントは必須です'
+  }
+  if (message.length > 200) {
+    return 'コメントは200文字以内で入力してください'
+  }
+  return ''
+}


### PR DESCRIPTION
## 課題のリンク

* https://github.com/happiness-chain/practice/blob/main/14.2_react/003_%E8%AA%B2%E9%A1%8C.md#%E3%82%B3%E3%83%A1%E3%83%B3%E3%83%88%E6%A9%9F%E8%83%BD

## やったこと

* コメント投稿機能を追加しました

## やらなかったこと

* コメント一覧に反映してないのでコメント投稿しても表示は変わりません

## 動作確認方法

### 準備
1. [会員登録画面](https://8tako8tako8.github.io/twitter_react/registration) または [ログイン画面](https://8tako8tako8.github.io/twitter_react/login)にアクセスし、ログインする
2. ツイート詳細に遷移する

### 動作確認
* ✅ コメントが投稿できること
* ✅ 投稿したコメントがデータベースに保存されていること

## キャプチャ

![demo](https://github.com/8tako8tako8/twitter_react/assets/65395999/414fe1e6-ef10-40ce-b2c1-b31339c86281)

```
irb(main):001:0> Comment.last
=> #<Comment:0x00007fe87e5831f8 id: 3, comment: "いいですね！", tweet_id: 33, user_id: 28, created_at: Thu, 12 Oct 2023 10:47:38.205715000 UTC +00:00, updated_at: Thu, 12 Oct 2023 10:47:38.205715000 UTC +00:00>
```

## その他

なし
