### PR TITLE
[fix] コメント投稿フォームのアバター画像を差し替える

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,8 +30,8 @@ const App: React.FC = () => {
     try {
       const res = await getCurrentUser()
       if (res && res.data) {
-        const { email, name, nickname, image, id } = res.data
-        dispatch(setCurrentUser({ email, name, nickname, image, id }))
+        const { email, name, nickname, avatarImageUrl, id } = res.data
+        dispatch(setCurrentUser({ email, name, nickname, avatarImageUrl, id }))
       }
     } catch (err) {
       console.error(err)

--- a/src/components/organisms/CommentBox.tsx
+++ b/src/components/organisms/CommentBox.tsx
@@ -1,4 +1,4 @@
-import { Avatar, Button } from '@mui/material'
+import { Button } from '@mui/material'
 import React, { useState } from 'react'
 import { styled } from 'styled-components'
 import { postComment } from '../../lib/api/comment'
@@ -6,6 +6,7 @@ import { validateCommentMessage } from '../../validators/commentValidator'
 import { ErrorMessage } from './ErrorMessage'
 import { useParams } from 'react-router-dom'
 import { FlashMessage } from './FlashMessage'
+import { useAppSelector } from '../../App'
 
 export const CommentBox: React.FC = () => {
   const [commentMessage, setCommentMessage] = useState('')
@@ -13,6 +14,8 @@ export const CommentBox: React.FC = () => {
   const [openSuccessMessage, setOpenSuccessMessage] = useState(false)
 
   const { tweetId } = useParams()
+
+  const myUser = useAppSelector((state) => state.user.userInfo)
 
   const handleSendComment = (e: React.FormEvent) => {
     e.preventDefault()
@@ -49,7 +52,11 @@ export const CommentBox: React.FC = () => {
       <CommentCard>
         <CommentForm onSubmit={handleSendComment}>
           <CommentInputBlock>
-            <Avatar />
+            {myUser && myUser.avatarImageUrl ? (
+              <AvatarImage src={myUser.avatarImageUrl} />
+            ) : (
+              <AvatarImage src={`${process.env.PUBLIC_URL}/no_image.png`} />
+            )}
             <CommentTextArea
               value={commentMessage}
               placeholder="コメントを投稿"
@@ -83,6 +90,12 @@ const CommentInputBlock = styled.div`
   padding: 20px;
   display: flex;
   width: 80%;
+`
+
+const AvatarImage = styled.img`
+  border-radius: 50%;
+  width: 50px;
+  height: 50px;
 `
 
 const CommentTextArea = styled.textarea`

--- a/src/components/pages/Login.tsx
+++ b/src/components/pages/Login.tsx
@@ -45,8 +45,10 @@ export const Login: React.FC = () => {
           })
           Cookies.set('_uid', res.headers['uid'] as string, { secure: true })
 
-          const { email, name, nickname, image, id } = res.data.data
-          dispatch(setCurrentUser({ email, name, nickname, image, id }))
+          const { email, name, nickname, avatarImageUrl, id } = res.data.data
+          dispatch(
+            setCurrentUser({ email, name, nickname, avatarImageUrl, id })
+          )
           setErrorMessage('')
 
           // ホーム画面に遷移させる

--- a/src/redux/userSlice.ts
+++ b/src/redux/userSlice.ts
@@ -3,9 +3,9 @@ import { PayloadAction, createSlice } from '@reduxjs/toolkit'
 type UserInfo = {
   id: number
   email: string
-  name?: string
-  nickname?: string
-  image?: string
+  name: string
+  nickname: string
+  avatarImageUrl: string
 }
 
 type User = {


### PR DESCRIPTION
## やったこと

* [セッション情報取得APIの変更](https://github.com/8tako8tako8/twitter_rails_api/pull/20) に合わせて、reduxに保持するデータを調整した
* コメント投稿フォームのアバター画像をユーザー本人のものに差し替えた