### PR TITLE
ツイート詳細画面にコメント一覧を追加

### DIFF
--- a/src/components/organisms/Comments.tsx
+++ b/src/components/organisms/Comments.tsx
@@ -81,7 +81,7 @@ export const Comments: React.FC = () => {
       {comments.map((comment) => (
         <Comment key={comment.id} comment={comment} />
       ))}
-      <div className="pagination">
+      <PaginationBlock className="pagination">
         <Pagination
           count={totalPages}
           page={currentPage}
@@ -90,17 +90,17 @@ export const Comments: React.FC = () => {
           size="small"
           onChange={handleChangePage}
         />
-      </div>
+      </PaginationBlock>
     </StyledComments>
   )
 }
 
-const StyledComments = styled.div`
-  .pagination {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    margin-top: 20px;
-    margin-bottom: 20px;
-  }
+const StyledComments = styled.div``
+
+const PaginationBlock = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-top: 20px;
+  margin-bottom: 20px;
 `

--- a/src/components/organisms/Comments.tsx
+++ b/src/components/organisms/Comments.tsx
@@ -14,6 +14,7 @@ type Comment = {
     nickname: string
     avatarImageUrl: string
   }
+  tweetId: number
   comment: string
 }
 

--- a/src/components/organisms/Comments.tsx
+++ b/src/components/organisms/Comments.tsx
@@ -42,16 +42,7 @@ export const Comments: React.FC = () => {
       .then((res) => {
         if (res && res.data) {
           setTotalPages((res.data.pagination.totalPages as number) || 1)
-          const resComments: Comment[] = (res.data.comments as Comment[]).map(
-            (comment) => {
-              return {
-                id: comment.id,
-                user: comment.user,
-                comment: comment.comment,
-              }
-            }
-          )
-          console.log(resComments)
+          const resComments: Comment[] = res.data.comments as Comment[]
           setComments(resComments)
         }
       })

--- a/src/lib/api/comment.ts
+++ b/src/lib/api/comment.ts
@@ -1,5 +1,16 @@
 import client from './client'
 
+const COMMENTS_PER_PAGE = 10
+
 export const postComment = (comment: string, tweetId: number) => {
   return client.post('comments', { comment, tweet_id: tweetId })
+}
+
+export const getComments = (tweetId: number, currentPage: number) => {
+  return client.get(`tweets/${tweetId}/comments`, {
+    params: {
+      limit: COMMENTS_PER_PAGE,
+      offset: currentPage,
+    },
+  })
 }


### PR DESCRIPTION
## 課題のリンク

* https://github.com/happiness-chain/practice/blob/main/14.2_react/003_%E8%AA%B2%E9%A1%8C.md#%E3%83%AA%E3%83%84%E3%82%A4%E3%83%BC%E3%83%88

## やったこと

* ツイート詳細画面にコメント一覧を追加しました！

## やらなかったこと

* 妥協したのですが、コメント投稿後に再度API叩いて値を取り直すことはしていません（課題的に要件満たさない指摘があれば対応しようと思います）
  * 代わりに投稿したフラッシュメッセージ出してます

## 動作確認方法

### 準備
1. [会員登録画面](https://8tako8tako8.github.io/twitter_react/registration) または [ログイン画面](https://8tako8tako8.github.io/twitter_react/login)にアクセスし、ログインする
2. ツイート詳細からコメントする

### 動作確認

* ✅ ツイート詳細画面にコメント一覧が表示されること

## キャプチャ

* ![コメント投稿のデモ](https://github.com/8tako8tako8/twitter_react/assets/65395999/cb379cba-b92f-46c6-9cf8-0680f1f851ba)

## その他

なし
