### PR TITLE
フォロー・フォロー解除機能を追加

### DIFF
--- a/src/components/organisms/Post.tsx
+++ b/src/components/organisms/Post.tsx
@@ -152,11 +152,13 @@ export const Post: React.FC<Props> = ({ post, myself, handleGetProfile }) => {
         <PostCardBody>
           <PostCardBodyTop>
             <PostCardBodyTopContents>
-              <PostCardHeaderName>
-                {post.user.nickname}
-                <VerifiedUserBadge />
-                <AccountName>{post.user.name}</AccountName>
-              </PostCardHeaderName>
+              <ProfileLink to={`${homeUrl}/users/${post.user.id}`}>
+                <PostCardHeaderName>
+                  {post.user.nickname}
+                  <VerifiedUserBadge />
+                  <AccountName>{post.user.name}</AccountName>
+                </PostCardHeaderName>
+              </ProfileLink>
               {myself && (
                 <DropDownMenu
                   open={openMenu}
@@ -254,6 +256,11 @@ const PostCardBodyTop = styled.div``
 const PostCardBodyTopContents = styled.div`
   display: flex;
   justify-content: space-between;
+`
+
+const ProfileLink = styled(Link)`
+  text-decoration: none;
+  color: inherit;
 `
 
 const PostCardHeaderName = styled.h3`

--- a/src/components/organisms/PostDetailBox.tsx
+++ b/src/components/organisms/PostDetailBox.tsx
@@ -12,6 +12,7 @@ import { useParams } from 'react-router-dom'
 import { Loading } from '../pages/Loading'
 import { cancelRetweet, retweet } from '../../lib/api/retweet'
 import { cancelFavorite, favorite } from '../../lib/api/favorite'
+import { Link } from 'react-router-dom'
 
 type Post = {
   id: number
@@ -28,6 +29,8 @@ type Post = {
   retweets: number
   favorites: number
 }
+
+const homeUrl = process.env.PUBLIC_URL
 
 export const PostDetailBox: React.FC = () => {
   const [post, setPost] = useState<Post>()
@@ -134,15 +137,17 @@ export const PostDetailBox: React.FC = () => {
         </div>
         <div className="postBody">
           <div className="postHeader">
-            <div className="postHeaderText">
-              <h3>
-                {post?.user.nickname}
-                <span className="postHeaderSpecial">
-                  <VerifiedUser className="postBadge" />
-                  {post?.user.name}
-                </span>
-              </h3>
-            </div>
+            <ProfileLink to={`${homeUrl}/users/${post?.user.id}`}>
+              <div className="postHeaderText">
+                <h3>
+                  {post?.user.nickname}
+                  <span className="postHeaderSpecial">
+                    <VerifiedUser className="postBadge" />
+                    {post?.user.name}
+                  </span>
+                </h3>
+              </div>
+            </ProfileLink>
             <div className="postHeaderDescription">
               <p>{post?.tweet}</p>
             </div>
@@ -257,6 +262,11 @@ const StyledPostDetailBox = styled.div`
   .postAvatar {
     padding: 15px;
   }
+`
+
+const ProfileLink = styled(Link)`
+  text-decoration: none;
+  color: inherit;
 `
 
 const RetweetIcon = styled(Repeat)`

--- a/src/components/organisms/ProfileDetail.tsx
+++ b/src/components/organisms/ProfileDetail.tsx
@@ -6,6 +6,7 @@ import React, { useState } from 'react'
 import { styled } from 'styled-components'
 import { ProfileDetailModal } from './ProfileDetailModal'
 import { ProfileSubInfo } from './ProfileSubInfo'
+import { follow, unfollow } from '../../lib/api/follow'
 
 type User = {
   id: number
@@ -17,6 +18,7 @@ type User = {
   introduction: string
   avatarImageUrl: string
   headerImageUrl: string
+  isFollowing: boolean
 }
 
 type Post = {
@@ -54,6 +56,40 @@ export const ProfileDetail: React.FC<Props> = ({
 
   const toggleModal = () => {
     setModalOpen(!isModalOpen)
+  }
+
+  const handleFollow = () => {
+    follow(profile.id)
+      .then((res) => {
+        if (res.status != 204) throw new Error('フォローに失敗しました')
+
+        setProfile((prevProfile) => {
+          return {
+            ...prevProfile,
+            isFollowing: true,
+          }
+        })
+      })
+      .catch((err) => {
+        console.error(err)
+      })
+  }
+
+  const handleUnfollow = () => {
+    unfollow(profile.id)
+      .then((res) => {
+        if (res.status != 204) throw new Error('フォロー解除に失敗しました')
+
+        setProfile((prevProfile) => {
+          return {
+            ...prevProfile,
+            isFollowing: false,
+          }
+        })
+      })
+      .catch((err) => {
+        console.error(err)
+      })
   }
 
   const PROFILE_SUB_INFO_LIST = [
@@ -103,6 +139,14 @@ export const ProfileDetail: React.FC<Props> = ({
               >
                 プロフィールを編集する
               </Button>
+            )}
+            {!myself && !profile.isFollowing && (
+              <FollowButton onClick={handleFollow}>フォローする</FollowButton>
+            )}
+            {!myself && profile.isFollowing && (
+              <UnfollowButton onClick={handleUnfollow}>
+                フォロー中
+              </UnfollowButton>
             )}
           </div>
           <h3>
@@ -206,4 +250,26 @@ const StyledProfileDetail = styled.div`
     align-items: center;
     color: gray;
   }
+`
+
+const FollowButton = styled(Button)`
+  background-color: var(--twitter-color) !important;
+  color: white !important;
+  font-weight: 900 !important;
+  width: 180px !important;
+  height: 40px !important;
+  border-radius: 30px !important;
+  margin-left: auto !important;
+  margin-right: 10px !important;
+`
+
+const UnfollowButton = styled(Button)`
+  background-color: gray !important;
+  color: white !important;
+  font-weight: 900 !important;
+  width: 180px !important;
+  height: 40px !important;
+  border-radius: 30px !important;
+  margin-left: auto !important;
+  margin-right: 10px !important;
 `

--- a/src/components/organisms/ProfileDetailModal.tsx
+++ b/src/components/organisms/ProfileDetailModal.tsx
@@ -22,6 +22,7 @@ type User = {
   introduction: string
   avatarImageUrl: string
   headerImageUrl: string
+  isFollowing: boolean
 }
 
 type Post = {

--- a/src/components/pages/Profile.tsx
+++ b/src/components/pages/Profile.tsx
@@ -17,6 +17,7 @@ type User = {
   introduction: string
   avatarImageUrl: string
   headerImageUrl: string
+  isFollowing: boolean
 }
 
 // TODO: リツイート、いいね機能、アバター画像後に削除する
@@ -30,6 +31,7 @@ const initialUser: User = {
   introduction: 'よろしくお願いします！',
   avatarImageUrl: 'https://source.unsplash.com/random',
   headerImageUrl: 'https://source.unsplash.com/random',
+  isFollowing: false,
 }
 
 type Post = {
@@ -87,6 +89,7 @@ export const Profile: React.FC = () => {
             introduction,
             avatarImageUrl,
             headerImageUrl,
+            isFollowing,
           } = res.data
           const resProfile: Profile = {
             ...initialUser,
@@ -99,6 +102,7 @@ export const Profile: React.FC = () => {
             introduction: introduction,
             avatarImageUrl: avatarImageUrl,
             headerImageUrl: headerImageUrl,
+            isFollowing: isFollowing,
           }
           setProfile(resProfile)
 

--- a/src/lib/api/follow.ts
+++ b/src/lib/api/follow.ts
@@ -1,0 +1,9 @@
+import client from './client'
+
+export const follow = (userId: number) => {
+  return client.post(`users/${userId}/follow`)
+}
+
+export const unfollow = (userId: number) => {
+  return client.post(`users/${userId}/unfollow`)
+}


### PR DESCRIPTION
## 課題のリンク

* https://github.com/happiness-chain/practice/blob/main/14.2_react/003_%E8%AA%B2%E9%A1%8C.md#%E3%83%95%E3%82%A9%E3%83%AD%E3%83%BC

## やったこと

* プロフィール画面でフォロー・フォロー解除できるようにした
* ツイート一覧・ツイート詳細のユーザー名からプロフィール画面に遷移できるようにした

## やらなかったこと

* なし

## 動作確認方法

### 準備
1. [会員登録画面](https://8tako8tako8.github.io/twitter_react/registration) または [ログイン画面](https://8tako8tako8.github.io/twitter_react/login)にアクセスし、ログインする
2. 他のユーザーのプロフィール画面に遷移する

### 動作確認

* ✅ フォローできること
* ✅ フォロー解除できること
* ✅ プロフィール取得時にフォロー済であればフォロー済がわかる表示になっていること
* ✅ ツイート一覧画面のユーザー名からプロフィール画面に遷移できること
* ✅ ツイート詳細画面のユーザー名からプロフィール画面に遷移できること

## キャプチャ

* <img width="500" alt="image" src="https://github.com/8tako8tako8/twitter_react/assets/65395999/fab50428-b75f-4939-a647-687d6e1de9b7">
* <img width="500" alt="image" src="https://github.com/8tako8tako8/twitter_react/assets/65395999/4099dba5-1a83-4e0e-8b00-5f1ecbf50e78">

## その他

なし
