### PR TITLE
通知一覧画面を追加

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import { setCurrentUser } from './redux/userSlice'
 import { Loading } from './components/pages/Loading'
 import { PostDetail } from './components/pages/PostDetail'
 import { Profile } from './components/pages/Profile'
+import { Notice } from './components/pages/Notice'
 
 export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector
 export const useAppDispatch = () => useDispatch<AppDispatch>()
@@ -65,6 +66,10 @@ const App: React.FC = () => {
         <Route
           path={homeUrl + '/users/:userId'}
           element={<PrivateRoute children={<Profile />} />}
+        />
+        <Route
+          path={homeUrl + '/notifications'}
+          element={<PrivateRoute children={<Notice />} />}
         />
         <Route path="*" element={<Error />} />
       </Routes>

--- a/src/components/organisms/Notification.tsx
+++ b/src/components/organisms/Notification.tsx
@@ -1,0 +1,59 @@
+import styled from 'styled-components'
+import { NotificationMessage } from './NotificationMessage'
+
+type Notification = {
+  id: number
+  subjectType: string
+  user: {
+    id: string
+    name: string
+    nickname: string
+    avatarImageUrl: string
+  }
+}
+
+type Props = {
+  notification: Notification
+}
+
+export const Notification: React.FC<Props> = ({ notification }) => {
+  return (
+    <StyledNotification>
+      <NotificationCard>
+        <AvatarImageBlock>
+          {notification.user.avatarImageUrl ? (
+            <AvatarImage src={notification.user.avatarImageUrl} />
+          ) : (
+            <AvatarImage src={`${process.env.PUBLIC_URL}/no_image.png`} />
+          )}
+        </AvatarImageBlock>
+        <NotificationCardBody>
+          <NotificationMessage notification={notification} />
+        </NotificationCardBody>
+      </NotificationCard>
+    </StyledNotification>
+  )
+}
+
+const StyledNotification = styled.div``
+
+const NotificationCard = styled.div`
+  display: flex;
+  align-items: flex-start;
+  border-bottom: 1px solid var(--twitter-background);
+`
+
+const AvatarImageBlock = styled.div`
+  padding: 15px;
+`
+
+const AvatarImage = styled.img`
+  border-radius: 50%;
+  width: 50px;
+  height: 50px;
+`
+
+const NotificationCardBody = styled.div`
+  flex: 1;
+  min-width: 0;
+`

--- a/src/components/organisms/NotificationMessage.tsx
+++ b/src/components/organisms/NotificationMessage.tsx
@@ -1,0 +1,46 @@
+import styled from 'styled-components'
+
+type Notification = {
+  id: number
+  subjectType: string
+  user: {
+    id: string
+    name: string
+    nickname: string
+    avatarImageUrl: string
+  }
+}
+
+type Props = {
+  notification: Notification
+}
+
+export const NotificationMessage: React.FC<Props> = ({ notification }) => {
+  if (notification.subjectType === 'comment') {
+    return (
+      <StyledNoticeMessage>
+        {notification.user.nickname}さんがあなたのツイートにコメントしました
+      </StyledNoticeMessage>
+    )
+  }
+
+  if (notification.subjectType === 'favorite') {
+    return (
+      <StyledNoticeMessage>
+        {notification.user.nickname}さんがあなたのツイートをいいねしました
+      </StyledNoticeMessage>
+    )
+  }
+
+  if (notification.subjectType === 'retweet') {
+    return (
+      <StyledNoticeMessage>
+        {notification.user.nickname}さんがあなたのツイートをリツイートしました
+      </StyledNoticeMessage>
+    )
+  }
+
+  return null
+}
+
+const StyledNoticeMessage = styled.p``

--- a/src/components/organisms/Notifications.tsx
+++ b/src/components/organisms/Notifications.tsx
@@ -101,10 +101,6 @@ export const Notifications: React.FC = () => {
     return <Loading />
   }
 
-  if (loading) {
-    return <Loading />
-  }
-
   return (
     <StyledNotifications>
       <NotificationHeader>

--- a/src/components/organisms/Notifications.tsx
+++ b/src/components/organisms/Notifications.tsx
@@ -1,0 +1,120 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { Pagination } from '@mui/material'
+import styled from 'styled-components'
+import { Loading } from '../pages/Loading'
+import { useNavigate } from 'react-router-dom'
+import { useState } from 'react'
+import { Notification } from './Notification'
+
+type Notification = {
+  id: number
+  subjectType: string
+  user: {
+    id: string
+    name: string
+    nickname: string
+    avatarImageUrl: string
+  }
+}
+
+const initialNotifications: Notification[] = [
+  {
+    id: 1,
+    subjectType: 'comment',
+    user: {
+      id: '1',
+      name: 'test',
+      nickname: 'test',
+      avatarImageUrl: '',
+    },
+  },
+  {
+    id: 2,
+    subjectType: 'favorite',
+    user: {
+      id: '1',
+      name: 'test',
+      nickname: 'test',
+      avatarImageUrl: '',
+    },
+  },
+  {
+    id: 3,
+    subjectType: 'retweet',
+    user: {
+      id: '1',
+      name: 'test',
+      nickname: 'test',
+      avatarImageUrl: '',
+    },
+  },
+]
+
+export const Notifications: React.FC = () => {
+  const [notifications, setNotifications] =
+    useState<Notification[]>(initialNotifications)
+  const [loading, setLoading] = useState<boolean>(false)
+  const [currentPage, setCurrentPage] = useState(1)
+  const [totalPages, setTotalPages] = useState(1)
+
+  const navigate = useNavigate()
+
+  const handleChangePage = (
+    _event: React.ChangeEvent<unknown>,
+    page: number
+  ) => {
+    setCurrentPage(page)
+    navigate({ ...location, search: `?page=${page}` })
+    // TODO: 通知一覧を取得する処理を追加する
+  }
+
+  if (loading) {
+    return <Loading />
+  }
+
+  return (
+    <StyledNotifications>
+      <NotificationHeader>
+        <HeaderText>通知</HeaderText>
+      </NotificationHeader>
+
+      {notifications.map((notification) => (
+        <Notification key={notification.id} notification={notification} />
+      ))}
+      <PaginationBlock>
+        <Pagination
+          count={totalPages}
+          page={currentPage}
+          variant="outlined"
+          color="primary"
+          size="small"
+          onChange={handleChangePage}
+        />
+      </PaginationBlock>
+    </StyledNotifications>
+  )
+}
+
+const StyledNotifications = styled.div``
+
+const NotificationHeader = styled.div`
+  position: sticky;
+  top: 0;
+  background-color: white;
+  z-index: 100;
+  border: 1px solid var(--twitter-background);
+  padding: 5px 20px;
+`
+
+const HeaderText = styled.h2`
+  font-size: 20px;
+  font-weight: 800;
+`
+
+const PaginationBlock = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-top: 20px;
+  margin-bottom: 20px;
+`

--- a/src/components/organisms/Notifications.tsx
+++ b/src/components/organisms/Notifications.tsx
@@ -3,8 +3,9 @@ import { Pagination } from '@mui/material'
 import styled from 'styled-components'
 import { Loading } from '../pages/Loading'
 import { useNavigate } from 'react-router-dom'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { Notification } from './Notification'
+import { getNotifications } from '../../lib/api/notification'
 
 type Notification = {
   id: number
@@ -65,7 +66,39 @@ export const Notifications: React.FC = () => {
   ) => {
     setCurrentPage(page)
     navigate({ ...location, search: `?page=${page}` })
-    // TODO: 通知一覧を取得する処理を追加する
+    handleGetNotifications(page)
+  }
+
+  const handleGetNotifications = (page: number) => {
+    setLoading(true)
+
+    getNotifications(page)
+      .then((res) => {
+        if (res && res.data) {
+          setTotalPages((res.data.pagination.totalPages as number) || 1)
+          const resNotifications: Notification[] = res.data.notifications
+          setNotifications(resNotifications)
+        }
+      })
+      .catch((err) => {
+        console.error(err)
+      })
+      .finally(() => {
+        setLoading(false)
+      })
+  }
+
+  useEffect(() => {
+    //  クエリパラメータからpageを取得する
+    const queryParams = new URLSearchParams(location.search)
+    const page = Number(queryParams.get('page')) || 1
+
+    setCurrentPage(page)
+    handleGetNotifications(page)
+  }, [location.search])
+
+  if (loading) {
+    return <Loading />
   }
 
   if (loading) {

--- a/src/components/organisms/Post.tsx
+++ b/src/components/organisms/Post.tsx
@@ -152,11 +152,13 @@ export const Post: React.FC<Props> = ({ post, myself, handleGetProfile }) => {
         <PostCardBody>
           <PostCardBodyTop>
             <PostCardBodyTopContents>
-              <PostCardHeaderName>
-                {post.user.nickname}
-                <VerifiedUserBadge />
-                <AccountName>{post.user.name}</AccountName>
-              </PostCardHeaderName>
+              <ProfileLink to={`${homeUrl}/users/${post.user.id}`}>
+                <PostCardHeaderName>
+                  {post.user.nickname}
+                  <VerifiedUserBadge />
+                  <AccountName>{post.user.name}</AccountName>
+                </PostCardHeaderName>
+              </ProfileLink>
               {myself && (
                 <DropDownMenu
                   open={openMenu}
@@ -254,6 +256,11 @@ const PostCardBodyTop = styled.div``
 const PostCardBodyTopContents = styled.div`
   display: flex;
   justify-content: space-between;
+`
+
+const ProfileLink = styled(Link)`
+  text-decoration: none;
+  color: inherit;
 `
 
 const PostCardHeaderName = styled.h3`

--- a/src/components/organisms/PostDetailBox.tsx
+++ b/src/components/organisms/PostDetailBox.tsx
@@ -12,6 +12,7 @@ import { useParams } from 'react-router-dom'
 import { Loading } from '../pages/Loading'
 import { cancelRetweet, retweet } from '../../lib/api/retweet'
 import { cancelFavorite, favorite } from '../../lib/api/favorite'
+import { Link } from 'react-router-dom'
 
 type Post = {
   id: number
@@ -28,6 +29,8 @@ type Post = {
   retweets: number
   favorites: number
 }
+
+const homeUrl = process.env.PUBLIC_URL
 
 export const PostDetailBox: React.FC = () => {
   const [post, setPost] = useState<Post>()
@@ -134,15 +137,17 @@ export const PostDetailBox: React.FC = () => {
         </div>
         <div className="postBody">
           <div className="postHeader">
-            <div className="postHeaderText">
-              <h3>
-                {post?.user.nickname}
-                <span className="postHeaderSpecial">
-                  <VerifiedUser className="postBadge" />
-                  {post?.user.name}
-                </span>
-              </h3>
-            </div>
+            <ProfileLink to={`${homeUrl}/users/${post?.user.id}`}>
+              <div className="postHeaderText">
+                <h3>
+                  {post?.user.nickname}
+                  <span className="postHeaderSpecial">
+                    <VerifiedUser className="postBadge" />
+                    {post?.user.name}
+                  </span>
+                </h3>
+              </div>
+            </ProfileLink>
             <div className="postHeaderDescription">
               <p>{post?.tweet}</p>
             </div>
@@ -257,6 +262,11 @@ const StyledPostDetailBox = styled.div`
   .postAvatar {
     padding: 15px;
   }
+`
+
+const ProfileLink = styled(Link)`
+  text-decoration: none;
+  color: inherit;
 `
 
 const RetweetIcon = styled(Repeat)`

--- a/src/components/organisms/ProfileDetail.tsx
+++ b/src/components/organisms/ProfileDetail.tsx
@@ -6,6 +6,7 @@ import React, { useState } from 'react'
 import { styled } from 'styled-components'
 import { ProfileDetailModal } from './ProfileDetailModal'
 import { ProfileSubInfo } from './ProfileSubInfo'
+import { follow, unfollow } from '../../lib/api/follow'
 
 type User = {
   id: number
@@ -17,6 +18,7 @@ type User = {
   introduction: string
   avatarImageUrl: string
   headerImageUrl: string
+  isFollowing: boolean
 }
 
 type Post = {
@@ -54,6 +56,40 @@ export const ProfileDetail: React.FC<Props> = ({
 
   const toggleModal = () => {
     setModalOpen(!isModalOpen)
+  }
+
+  const handleFollow = () => {
+    follow(profile.id)
+      .then((res) => {
+        if (res.status != 204) throw new Error('フォローに失敗しました')
+
+        setProfile((prevProfile) => {
+          return {
+            ...prevProfile,
+            isFollowing: true,
+          }
+        })
+      })
+      .catch((err) => {
+        console.error(err)
+      })
+  }
+
+  const handleUnfollow = () => {
+    unfollow(profile.id)
+      .then((res) => {
+        if (res.status != 204) throw new Error('フォロー解除に失敗しました')
+
+        setProfile((prevProfile) => {
+          return {
+            ...prevProfile,
+            isFollowing: false,
+          }
+        })
+      })
+      .catch((err) => {
+        console.error(err)
+      })
   }
 
   const PROFILE_SUB_INFO_LIST = [
@@ -103,6 +139,14 @@ export const ProfileDetail: React.FC<Props> = ({
               >
                 プロフィールを編集する
               </Button>
+            )}
+            {!myself && !profile.isFollowing && (
+              <FollowButton onClick={handleFollow}>フォローする</FollowButton>
+            )}
+            {!myself && profile.isFollowing && (
+              <UnfollowButton onClick={handleUnfollow}>
+                フォロー中
+              </UnfollowButton>
             )}
           </div>
           <h3>
@@ -206,4 +250,26 @@ const StyledProfileDetail = styled.div`
     align-items: center;
     color: gray;
   }
+`
+
+const FollowButton = styled(Button)`
+  background-color: var(--twitter-color) !important;
+  color: white !important;
+  font-weight: 900 !important;
+  width: 180px !important;
+  height: 40px !important;
+  border-radius: 30px !important;
+  margin-left: auto !important;
+  margin-right: 10px !important;
+`
+
+const UnfollowButton = styled(Button)`
+  background-color: gray !important;
+  color: white !important;
+  font-weight: 900 !important;
+  width: 180px !important;
+  height: 40px !important;
+  border-radius: 30px !important;
+  margin-left: auto !important;
+  margin-right: 10px !important;
 `

--- a/src/components/organisms/ProfileDetailModal.tsx
+++ b/src/components/organisms/ProfileDetailModal.tsx
@@ -22,6 +22,7 @@ type User = {
   introduction: string
   avatarImageUrl: string
   headerImageUrl: string
+  isFollowing: boolean
 }
 
 type Post = {

--- a/src/components/pages/Notice.tsx
+++ b/src/components/pages/Notice.tsx
@@ -1,0 +1,38 @@
+import styled from 'styled-components'
+import { SideBar } from '../templates/SideBar'
+import { Notifications } from '../organisms/Notifications'
+
+export const Notice: React.FC = () => {
+  return (
+    <StyledNotice>
+      <SideBarBlock>
+        <SideBar />
+      </SideBarBlock>
+      <NotificationBlock>
+        <Notifications />
+      </NotificationBlock>
+    </StyledNotice>
+  )
+}
+
+const StyledNotice = styled.div`
+  display: flex;
+  height: 100vh;
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 0 10px;
+`
+
+const SideBarBlock = styled.div`
+  border-right: 1px solid var(--twitter-background);
+  min-width: 300px;
+  margin-top: 20px;
+  padding-left: 20px;
+  padding-right: 20px;
+`
+
+const NotificationBlock = styled.div`
+  min-width: 600px;
+  border-right: 1px solid var(--twitter-background);
+  overflow-y: scroll;
+`

--- a/src/components/pages/Profile.tsx
+++ b/src/components/pages/Profile.tsx
@@ -17,6 +17,7 @@ type User = {
   introduction: string
   avatarImageUrl: string
   headerImageUrl: string
+  isFollowing: boolean
 }
 
 // TODO: リツイート、いいね機能、アバター画像後に削除する
@@ -30,6 +31,7 @@ const initialUser: User = {
   introduction: 'よろしくお願いします！',
   avatarImageUrl: 'https://source.unsplash.com/random',
   headerImageUrl: 'https://source.unsplash.com/random',
+  isFollowing: false,
 }
 
 type Post = {
@@ -87,6 +89,7 @@ export const Profile: React.FC = () => {
             introduction,
             avatarImageUrl,
             headerImageUrl,
+            isFollowing,
           } = res.data
           const resProfile: Profile = {
             ...initialUser,
@@ -99,6 +102,7 @@ export const Profile: React.FC = () => {
             introduction: introduction,
             avatarImageUrl: avatarImageUrl,
             headerImageUrl: headerImageUrl,
+            isFollowing: isFollowing,
           }
           setProfile(resProfile)
 

--- a/src/lib/api/follow.ts
+++ b/src/lib/api/follow.ts
@@ -1,0 +1,9 @@
+import client from './client'
+
+export const follow = (userId: number) => {
+  return client.post(`users/${userId}/follow`)
+}
+
+export const unfollow = (userId: number) => {
+  return client.post(`users/${userId}/unfollow`)
+}

--- a/src/lib/api/notification.ts
+++ b/src/lib/api/notification.ts
@@ -1,0 +1,12 @@
+import client from './client'
+
+const NOTIFICATIONS_PER_PAGE = 10
+
+export const getNotifications = (currentPage: number) => {
+  return client.get(`notifications`, {
+    params: {
+      limit: NOTIFICATIONS_PER_PAGE,
+      offset: currentPage,
+    },
+  })
+}


### PR DESCRIPTION
## 課題のリンク

* https://github.com/happiness-chain/practice/blob/main/14.2_react/003_%E8%AA%B2%E9%A1%8C.md#%E9%80%9A%E7%9F%A5

## やったこと

* 通知一覧画面を追加した
* サイドバーの通知から通知一覧画面に遷移できるようにした

## やらなかったこと

* なし

## 動作確認方法

### 準備
1. [会員登録画面](https://8tako8tako8.github.io/twitter_react/registration) または [ログイン画面](https://8tako8tako8.github.io/twitter_react/login)にアクセスし、ログインする
2. 他の自分のユーザーのツイートにコメント、いいね、リツイートする
3. 通知のきたユーザーにログインする

### 動作確認

* ✅ 通知一覧画面が表示されること
* ✅ サイドバーから通知一覧画面に遷移できること

## キャプチャ

* ![image](https://github.com/8tako8tako8/twitter_react/assets/65395999/189a0482-5aeb-424d-928f-aaf5a17140fc)

## その他

なし
