### PR TITLE
ダイレクトメッセージ画面を追加

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ import { Loading } from './components/pages/Loading'
 import { PostDetail } from './components/pages/PostDetail'
 import { Profile } from './components/pages/Profile'
 import { Notice } from './components/pages/Notice'
+import { DirectMessage } from './components/pages/DirectMessage'
 
 export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector
 export const useAppDispatch = () => useDispatch<AppDispatch>()
@@ -70,6 +71,10 @@ const App: React.FC = () => {
         <Route
           path={homeUrl + '/notifications'}
           element={<PrivateRoute children={<Notice />} />}
+        />
+        <Route
+          path={homeUrl + '/messages'}
+          element={<PrivateRoute children={<DirectMessage />} />}
         />
         <Route path="*" element={<Error />} />
       </Routes>

--- a/src/components/organisms/Group.tsx
+++ b/src/components/organisms/Group.tsx
@@ -1,17 +1,35 @@
 import React from 'react'
 import { styled } from 'styled-components'
 
-export const Group: React.FC = () => {
-  const nickName = 'aaaabbbbxx'
+type User = {
+  id: number
+  name: string
+  nickname: string
+  avatarImageUrl: string
+}
 
+type Group = {
+  id: number
+  user: User
+}
+
+type Props = {
+  group: Group
+}
+
+export const Group: React.FC<Props> = ({ group }) => {
   return (
     <StyledGroup>
       <GroupCard>
         <AvatarImageBlock>
-          {true && <AvatarImage src="https://source.unsplash.com/random" />}
+          {group.user.avatarImageUrl ? (
+            <AvatarImage src={group.user.avatarImageUrl} />
+          ) : (
+            <AvatarImage src={`${process.env.PUBLIC_URL}/no_image.png`} />
+          )}
         </AvatarImageBlock>
         <GroupCardBody>
-          <GroupCardName>{nickName}</GroupCardName>
+          <GroupCardName>{group.user.nickname}</GroupCardName>
         </GroupCardBody>
       </GroupCard>
     </StyledGroup>

--- a/src/components/organisms/Group.tsx
+++ b/src/components/organisms/Group.tsx
@@ -15,33 +15,66 @@ type Group = {
 
 type Props = {
   group: Group
+  selectedGroup: Group
+  setSelectedGroup: React.Dispatch<React.SetStateAction<Group>>
 }
 
-export const Group: React.FC<Props> = ({ group }) => {
+export const Group: React.FC<Props> = ({
+  group,
+  selectedGroup,
+  setSelectedGroup,
+}) => {
+  const handleSetSelectedGroup = () => {
+    setSelectedGroup(group)
+  }
+
   return (
-    <StyledGroup>
-      <GroupCard>
-        <AvatarImageBlock>
-          {group.user.avatarImageUrl ? (
-            <AvatarImage src={group.user.avatarImageUrl} />
-          ) : (
-            <AvatarImage src={`${process.env.PUBLIC_URL}/no_image.png`} />
-          )}
-        </AvatarImageBlock>
-        <GroupCardBody>
-          <GroupCardName>{group.user.nickname}</GroupCardName>
-        </GroupCardBody>
-      </GroupCard>
+    <StyledGroup onClick={handleSetSelectedGroup}>
+      {selectedGroup.id === group.id && (
+        <ActiveGroupCard>
+          <AvatarImageBlock>
+            {group.user.avatarImageUrl ? (
+              <AvatarImage src={group.user.avatarImageUrl} />
+            ) : (
+              <AvatarImage src={`${process.env.PUBLIC_URL}/no_image.png`} />
+            )}
+          </AvatarImageBlock>
+          <GroupCardBody>
+            <GroupCardName>{group.user.nickname}</GroupCardName>
+          </GroupCardBody>
+        </ActiveGroupCard>
+      )}
+      {selectedGroup.id !== group.id && (
+        <InactiveGroupCard>
+          <AvatarImageBlock>
+            {group.user.avatarImageUrl ? (
+              <AvatarImage src={group.user.avatarImageUrl} />
+            ) : (
+              <AvatarImage src={`${process.env.PUBLIC_URL}/no_image.png`} />
+            )}
+          </AvatarImageBlock>
+          <GroupCardBody>
+            <GroupCardName>{group.user.nickname}</GroupCardName>
+          </GroupCardBody>
+        </InactiveGroupCard>
+      )}
     </StyledGroup>
   )
 }
 
 const StyledGroup = styled.div``
 
-const GroupCard = styled.div`
+const InactiveGroupCard = styled.div`
   display: flex;
   align-items: flex-start;
   border-bottom: 1px solid var(--twitter-background);
+`
+
+const ActiveGroupCard = styled.div`
+  display: flex;
+  align-items: flex-start;
+  border-bottom: 1px solid var(--twitter-background);
+  background-color: lightgrey;
 `
 
 const AvatarImage = styled.img`

--- a/src/components/organisms/Group.tsx
+++ b/src/components/organisms/Group.tsx
@@ -1,0 +1,47 @@
+import React from 'react'
+import { styled } from 'styled-components'
+
+export const Group: React.FC = () => {
+  const nickName = 'aaaabbbbxx'
+
+  return (
+    <StyledGroup>
+      <GroupCard>
+        <AvatarImageBlock>
+          {true && <AvatarImage src="https://source.unsplash.com/random" />}
+        </AvatarImageBlock>
+        <GroupCardBody>
+          <GroupCardName>{nickName}</GroupCardName>
+        </GroupCardBody>
+      </GroupCard>
+    </StyledGroup>
+  )
+}
+
+const StyledGroup = styled.div``
+
+const GroupCard = styled.div`
+  display: flex;
+  align-items: flex-start;
+  border-bottom: 1px solid var(--twitter-background);
+`
+
+const AvatarImage = styled.img`
+  border-radius: 50%;
+  width: 50px;
+  height: 50px;
+`
+
+const AvatarImageBlock = styled.div`
+  padding: 15px;
+`
+
+const GroupCardBody = styled.div`
+  flex: 1;
+  min-width: 0;
+`
+
+const GroupCardName = styled.h3`
+  font-size: 15px;
+  margin-bottom: 5px;
+`

--- a/src/components/organisms/Group.tsx
+++ b/src/components/organisms/Group.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { useNavigate } from 'react-router-dom'
 import { styled } from 'styled-components'
 
 type User = {
@@ -24,7 +25,10 @@ export const Group: React.FC<Props> = ({
   selectedGroup,
   setSelectedGroup,
 }) => {
+  const navigate = useNavigate()
+
   const handleSetSelectedGroup = () => {
+    navigate({ ...location, search: `?group_id=${group.id}` })
     setSelectedGroup(group)
   }
 

--- a/src/components/organisms/Groups.tsx
+++ b/src/components/organisms/Groups.tsx
@@ -16,13 +16,24 @@ type Group = {
 
 type Props = {
   groups: Group[]
+  selectedGroup: Group
+  setSelectedGroup: React.Dispatch<React.SetStateAction<Group>>
 }
 
-export const Groups: React.FC<Props> = ({ groups }) => {
+export const Groups: React.FC<Props> = ({
+  groups,
+  selectedGroup,
+  setSelectedGroup,
+}) => {
   return (
     <StyledGroups>
       {groups.map((group) => (
-        <Group key={group.id} group={group} />
+        <Group
+          key={group.id}
+          group={group}
+          selectedGroup={selectedGroup}
+          setSelectedGroup={setSelectedGroup}
+        />
       ))}
     </StyledGroups>
   )

--- a/src/components/organisms/Groups.tsx
+++ b/src/components/organisms/Groups.tsx
@@ -1,0 +1,16 @@
+import React from 'react'
+import { styled } from 'styled-components'
+import { Group } from './Group'
+
+export const Groups: React.FC = () => {
+  return (
+    <StyledGroups>
+      <Group />
+      <Group />
+      <Group />
+      <Group />
+    </StyledGroups>
+  )
+}
+
+const StyledGroups = styled.div``

--- a/src/components/organisms/Groups.tsx
+++ b/src/components/organisms/Groups.tsx
@@ -2,13 +2,28 @@ import React from 'react'
 import { styled } from 'styled-components'
 import { Group } from './Group'
 
-export const Groups: React.FC = () => {
+type User = {
+  id: number
+  name: string
+  nickname: string
+  avatarImageUrl: string
+}
+
+type Group = {
+  id: number
+  user: User
+}
+
+type Props = {
+  groups: Group[]
+}
+
+export const Groups: React.FC<Props> = ({ groups }) => {
   return (
     <StyledGroups>
-      <Group />
-      <Group />
-      <Group />
-      <Group />
+      {groups.map((group) => (
+        <Group key={group.id} group={group} />
+      ))}
     </StyledGroups>
   )
 }

--- a/src/components/organisms/Message.tsx
+++ b/src/components/organisms/Message.tsx
@@ -1,0 +1,73 @@
+import React from 'react'
+import { styled } from 'styled-components'
+
+type Props = {
+  myself: boolean
+}
+
+export const Message: React.FC<Props> = ({ myself }) => {
+  const message =
+    'ああああああああああああああああああああああああああああああああああああああああああああああ'
+
+  return (
+    <StyledMessage>
+      <>
+        {myself && (
+          <MyMessageBlock>
+            <MyMessageContainer>
+              <MyMessage>{message}</MyMessage>
+            </MyMessageContainer>
+          </MyMessageBlock>
+        )}
+        {!myself && (
+          <YourMessageBlock>
+            <YourMessageContainer>
+              <YourMessage>{message}</YourMessage>
+            </YourMessageContainer>
+          </YourMessageBlock>
+        )}
+      </>
+    </StyledMessage>
+  )
+}
+
+const StyledMessage = styled.div``
+
+const MyMessageBlock = styled.div`
+  display: flex;
+  align-items: flex-start;
+  justify-content: flex-end;
+  margin-right: 10px;
+`
+
+const MyMessageContainer = styled.div`
+  border-radius: 10px;
+  padding: 5px 10px;
+  margin: 5px;
+  background-color: var(--twitter-color);
+`
+
+const YourMessageBlock = styled.div`
+  display: flex;
+  align-items: flex-start;
+  justify-content: flex-start;
+  margin-left: 10px;
+`
+
+const YourMessageContainer = styled.div`
+  border: 1px solid #ccc;
+  border-radius: 10px;
+  padding: 5px 10px;
+  margin: 5px;
+`
+
+const MyMessage = styled.h3`
+  font-size: 15px;
+  color: white;
+  margin: 0;
+`
+
+const YourMessage = styled.h3`
+  font-size: 15px;
+  margin: 0;
+`

--- a/src/components/organisms/Message.tsx
+++ b/src/components/organisms/Message.tsx
@@ -1,13 +1,27 @@
 import React from 'react'
 import { styled } from 'styled-components'
+import { useAppSelector } from '../../App'
 
-type Props = {
-  myself: boolean
+type Message = {
+  id: number
+  message: string
+  user: {
+    id: number
+    name: string
+    nickname: string
+    avatarImageUrl: string
+  }
+  createdAt: string
+  updatedAt: string
 }
 
-export const Message: React.FC<Props> = ({ myself }) => {
-  const message =
-    'ああああああああああああああああああああああああああああああああああああああああああああああ'
+type Props = {
+  message: Message
+}
+
+export const Message: React.FC<Props> = ({ message }) => {
+  const myUserId = useAppSelector((state) => state.user.userInfo?.id)
+  const myself = message.user.id === myUserId
 
   return (
     <StyledMessage>
@@ -15,14 +29,14 @@ export const Message: React.FC<Props> = ({ myself }) => {
         {myself && (
           <MyMessageBlock>
             <MyMessageContainer>
-              <MyMessage>{message}</MyMessage>
+              <MyMessage>{message.message}</MyMessage>
             </MyMessageContainer>
           </MyMessageBlock>
         )}
         {!myself && (
           <YourMessageBlock>
             <YourMessageContainer>
-              <YourMessage>{message}</YourMessage>
+              <YourMessage>{message.message}</YourMessage>
             </YourMessageContainer>
           </YourMessageBlock>
         )}

--- a/src/components/organisms/Message.tsx
+++ b/src/components/organisms/Message.tsx
@@ -59,6 +59,8 @@ const MyMessageContainer = styled.div`
   padding: 5px 10px;
   margin: 5px;
   background-color: var(--twitter-color);
+  max-width: 200px;
+  word-wrap: break-word;
 `
 
 const YourMessageBlock = styled.div`
@@ -73,6 +75,8 @@ const YourMessageContainer = styled.div`
   border-radius: 10px;
   padding: 5px 10px;
   margin: 5px;
+  max-width: 200px;
+  word-wrap: break-word;
 `
 
 const MyMessage = styled.h3`

--- a/src/components/organisms/MessageBox.tsx
+++ b/src/components/organisms/MessageBox.tsx
@@ -1,0 +1,65 @@
+import { Button } from '@mui/material'
+import React, { useState } from 'react'
+import { styled } from 'styled-components'
+
+export const MessageBox: React.FC = () => {
+  const [message, setMessage] = useState('')
+
+  return (
+    <StyledMessageBox>
+      <MessageCard>
+        <MessageForm>
+          <MessageInputBlock>
+            <MessageTextArea
+              value={message}
+              placeholder="メッセージを投稿"
+              onChange={(e) => setMessage(e.target.value)}
+            />
+          </MessageInputBlock>
+          <MessageButton type="submit">送信</MessageButton>
+        </MessageForm>
+      </MessageCard>
+    </StyledMessageBox>
+  )
+}
+
+const StyledMessageBox = styled.div``
+
+const MessageCard = styled.div`
+  padding-bottom: 10px;
+  padding-right: 10px;
+  border-top: 1px solid var(--twitter-background);
+  border-bottom: 1px solid var(--twitter-background);
+`
+
+const MessageForm = styled.form`
+  display: flex;
+  justify-content: space-between;
+`
+
+const MessageInputBlock = styled.div`
+  padding: 20px;
+  display: flex;
+  width: 80%;
+`
+
+const MessageTextArea = styled.textarea`
+  flex: 1;
+  font-size: 20px;
+  margin-left: 20px;
+  border: none;
+  resize: none;
+  overflow: auto;
+  min-width: 0;
+`
+
+const MessageButton = styled(Button)`
+  background-color: var(--twitter-color) !important;
+  color: white !important;
+  font-weight: 900 !important;
+  width: 80px !important;
+  height: 40px !important;
+  border-radius: 30px !important;
+  margin-left: auto !important;
+  margin-top: 20px !important;
+`

--- a/src/components/organisms/MessageBox.tsx
+++ b/src/components/organisms/MessageBox.tsx
@@ -1,19 +1,50 @@
 import { Button } from '@mui/material'
 import React, { useState } from 'react'
 import { styled } from 'styled-components'
+import { sendMessage } from '../../lib/api/message'
+import { validateDirectMessage } from '../../validators/messageValidator'
 
-export const MessageBox: React.FC = () => {
-  const [message, setMessage] = useState('')
+type Props = {
+  groupId: number
+  handleGetMessages: (groupId: number) => void
+}
+
+export const MessageBox: React.FC<Props> = ({ groupId, handleGetMessages }) => {
+  const [directMessage, setDirectMessage] = useState('')
+
+  const handleSendMessage = (e: React.FormEvent) => {
+    e.preventDefault()
+
+    const validationError = validateDirectMessage(directMessage)
+    if (validationError) {
+      // setErrorMessage(validationError)
+      return
+    }
+
+    sendMessage(directMessage, groupId)
+      .then((res) => {
+        if (res.status != 201) throw new Error('に失敗しました')
+
+        setDirectMessage('')
+        // setErrorMessage('')
+
+        handleGetMessages(groupId)
+      })
+      .catch((err) => {
+        // setErrorMessage((err.message || err) as string)
+        console.error(err)
+      })
+  }
 
   return (
     <StyledMessageBox>
       <MessageCard>
-        <MessageForm>
+        <MessageForm onSubmit={handleSendMessage}>
           <MessageInputBlock>
             <MessageTextArea
-              value={message}
+              value={directMessage}
               placeholder="メッセージを投稿"
-              onChange={(e) => setMessage(e.target.value)}
+              onChange={(e) => setDirectMessage(e.target.value)}
             />
           </MessageInputBlock>
           <MessageButton type="submit">送信</MessageButton>

--- a/src/components/organisms/MessageBox.tsx
+++ b/src/components/organisms/MessageBox.tsx
@@ -1,5 +1,5 @@
 import { Button } from '@mui/material'
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { styled } from 'styled-components'
 import { sendMessage } from '../../lib/api/message'
 import { validateDirectMessage } from '../../validators/messageValidator'
@@ -37,6 +37,11 @@ export const MessageBox: React.FC<Props> = ({ groupId, handleGetMessages }) => {
         console.error(err)
       })
   }
+
+  useEffect(() => {
+    setDirectMessage('')
+    setErrorMessage('')
+  }, [groupId])
 
   return (
     <StyledMessageBox>

--- a/src/components/organisms/MessageBox.tsx
+++ b/src/components/organisms/MessageBox.tsx
@@ -3,6 +3,7 @@ import React, { useState } from 'react'
 import { styled } from 'styled-components'
 import { sendMessage } from '../../lib/api/message'
 import { validateDirectMessage } from '../../validators/messageValidator'
+import { ErrorMessage } from './ErrorMessage'
 
 type Props = {
   groupId: number
@@ -11,13 +12,14 @@ type Props = {
 
 export const MessageBox: React.FC<Props> = ({ groupId, handleGetMessages }) => {
   const [directMessage, setDirectMessage] = useState('')
+  const [errorMessage, setErrorMessage] = useState('')
 
   const handleSendMessage = (e: React.FormEvent) => {
     e.preventDefault()
 
     const validationError = validateDirectMessage(directMessage)
     if (validationError) {
-      // setErrorMessage(validationError)
+      setErrorMessage(validationError)
       return
     }
 
@@ -26,12 +28,12 @@ export const MessageBox: React.FC<Props> = ({ groupId, handleGetMessages }) => {
         if (res.status != 201) throw new Error('に失敗しました')
 
         setDirectMessage('')
-        // setErrorMessage('')
+        setErrorMessage('')
 
         handleGetMessages(groupId)
       })
       .catch((err) => {
-        // setErrorMessage((err.message || err) as string)
+        setErrorMessage((err.message || err) as string)
         console.error(err)
       })
   }
@@ -50,6 +52,7 @@ export const MessageBox: React.FC<Props> = ({ groupId, handleGetMessages }) => {
           <MessageButton type="submit">送信</MessageButton>
         </MessageForm>
       </MessageCard>
+      {errorMessage !== '' && <ErrorMessage>{errorMessage}</ErrorMessage>}
     </StyledMessageBox>
   )
 }

--- a/src/components/organisms/Messages.tsx
+++ b/src/components/organisms/Messages.tsx
@@ -1,7 +1,6 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect } from 'react'
 import { styled } from 'styled-components'
 import { Message } from './Message'
-import { getMessages } from '../../lib/api/message'
 
 type Message = {
   id: number
@@ -27,26 +26,19 @@ type Group = {
 }
 
 type Props = {
+  messages: Message[]
   selectedGroup: Group
+  handleGetMessages: (groupId: number) => void
 }
 
-export const Messages: React.FC<Props> = ({ selectedGroup }) => {
-  const [messages, setMessages] = useState<Message[]>([])
-
-  const handleGetMessages = (groupId: number) => {
-    getMessages(groupId)
-      .then((res) => {
-        const resMessages: Message[] = res.data.messages
-        setMessages(resMessages)
-      })
-      .catch((err) => {
-        console.error(err)
-      })
-  }
-
+export const Messages: React.FC<Props> = ({
+  messages,
+  selectedGroup,
+  handleGetMessages,
+}) => {
   useEffect(() => {
     handleGetMessages(selectedGroup.id)
-  }, [])
+  }, [selectedGroup.id])
 
   return (
     <StyledMessages>

--- a/src/components/organisms/Messages.tsx
+++ b/src/components/organisms/Messages.tsx
@@ -1,18 +1,58 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import { styled } from 'styled-components'
 import { Message } from './Message'
+import { getMessages } from '../../lib/api/message'
 
-export const Messages: React.FC = () => {
+type Message = {
+  id: number
+  message: string
+  user: {
+    id: number
+    name: string
+    nickname: string
+    avatarImageUrl: string
+  }
+  createdAt: string
+  updatedAt: string
+}
+
+type Group = {
+  id: number
+  user: {
+    id: number
+    name: string
+    nickname: string
+    avatarImageUrl: string
+  }
+}
+
+type Props = {
+  selectedGroup: Group
+}
+
+export const Messages: React.FC<Props> = ({ selectedGroup }) => {
+  const [messages, setMessages] = useState<Message[]>([])
+
+  const handleGetMessages = (groupId: number) => {
+    getMessages(groupId)
+      .then((res) => {
+        const resMessages: Message[] = res.data.messages
+        setMessages(resMessages)
+      })
+      .catch((err) => {
+        console.error(err)
+      })
+  }
+
+  useEffect(() => {
+    handleGetMessages(selectedGroup.id)
+  }, [])
+
   return (
     <StyledMessages>
-      <Message myself={true} />
-      <Message myself={false} />
-      <Message myself={true} />
-      <Message myself={false} />
-      <Message myself={false} />
-      <Message myself={false} />
-      <Message myself={false} />
-      <Message myself={false} />
+      {messages.map((message) => (
+        <Message key={message.id} message={message} />
+      ))}
     </StyledMessages>
   )
 }

--- a/src/components/organisms/Messages.tsx
+++ b/src/components/organisms/Messages.tsx
@@ -15,14 +15,16 @@ type Message = {
   updatedAt: string
 }
 
+type User = {
+  id: number
+  name: string
+  nickname: string
+  avatarImageUrl: string
+}
+
 type Group = {
   id: number
-  user: {
-    id: number
-    name: string
-    nickname: string
-    avatarImageUrl: string
-  }
+  user: User
 }
 
 type Props = {

--- a/src/components/organisms/Messages.tsx
+++ b/src/components/organisms/Messages.tsx
@@ -1,0 +1,22 @@
+import React from 'react'
+import { styled } from 'styled-components'
+import { Message } from './Message'
+
+export const Messages: React.FC = () => {
+  return (
+    <StyledMessages>
+      <Message myself={true} />
+      <Message myself={false} />
+      <Message myself={true} />
+      <Message myself={false} />
+      <Message myself={false} />
+      <Message myself={false} />
+      <Message myself={false} />
+      <Message myself={false} />
+    </StyledMessages>
+  )
+}
+
+const StyledMessages = styled.div`
+  margin-bottom: 10px;
+`

--- a/src/components/organisms/ProfileDetail.tsx
+++ b/src/components/organisms/ProfileDetail.tsx
@@ -98,6 +98,25 @@ export const ProfileDetail: React.FC<Props> = ({
       })
   }
 
+  const handleFindMessageGroup = () => {
+    findOrCreateGroup(profile.id)
+      .then((res) => {
+        if (res.status !== 200)
+          throw new Error('メッセージグループの取得に失敗しました')
+
+        if (res && res.data) {
+          const group_id = res.data.group.id
+          navigate({
+            pathname: `${homeUrl}/messages`,
+            search: `?group_id=${group_id}`,
+          })
+        }
+      })
+      .catch((err) => {
+        console.error(err)
+      })
+  }
+
   const PROFILE_SUB_INFO_LIST = [
     {
       class: 'profileBodySubInfoLocation',

--- a/src/components/organisms/ProfileDetail.tsx
+++ b/src/components/organisms/ProfileDetail.tsx
@@ -7,6 +7,8 @@ import { styled } from 'styled-components'
 import { ProfileDetailModal } from './ProfileDetailModal'
 import { ProfileSubInfo } from './ProfileSubInfo'
 import { follow, unfollow } from '../../lib/api/follow'
+import { findOrCreateGroup } from '../../lib/api/group'
+import { useNavigate } from 'react-router-dom'
 
 type User = {
   id: number
@@ -47,12 +49,16 @@ type Props = {
   myself: boolean
 }
 
+const homeUrl = process.env.PUBLIC_URL
+
 export const ProfileDetail: React.FC<Props> = ({
   profile,
   setProfile,
   myself,
 }) => {
   const [isModalOpen, setModalOpen] = useState(false)
+
+  const navigate = useNavigate()
 
   const toggleModal = () => {
     setModalOpen(!isModalOpen)
@@ -132,22 +138,36 @@ export const ProfileDetail: React.FC<Props> = ({
                 <img src={`${process.env.PUBLIC_URL}/no_image.png`} />
               )}
             </div>
-            {myself && (
-              <Button
-                className="profileBodyTopEditButton"
-                onClick={toggleModal}
-              >
-                プロフィールを編集する
-              </Button>
-            )}
-            {!myself && !profile.isFollowing && (
-              <FollowButton onClick={handleFollow}>フォローする</FollowButton>
-            )}
-            {!myself && profile.isFollowing && (
-              <UnfollowButton onClick={handleUnfollow}>
-                フォロー中
-              </UnfollowButton>
-            )}
+
+            <ButtonBlock>
+              <PersonalButtonBlock>
+                {myself && (
+                  <Button
+                    className="profileBodyTopEditButton"
+                    onClick={toggleModal}
+                  >
+                    プロフィールを編集する
+                  </Button>
+                )}
+                {!myself && (
+                  <MessageButton onClick={handleFindMessageGroup}>
+                    メッセージを送る
+                  </MessageButton>
+                )}
+              </PersonalButtonBlock>
+              <FollowButtonBlock>
+                {!myself && !profile.isFollowing && (
+                  <FollowButton onClick={handleFollow}>
+                    フォローする
+                  </FollowButton>
+                )}
+                {!myself && profile.isFollowing && (
+                  <UnfollowButton onClick={handleUnfollow}>
+                    フォロー中
+                  </UnfollowButton>
+                )}
+              </FollowButtonBlock>
+            </ButtonBlock>
           </div>
           <h3>
             {profile.nickname}
@@ -206,7 +226,7 @@ const StyledProfileDetail = styled.div`
 
   .profileBodyTop {
     display: flex;
-    align-items: center;
+    justify-content: space-between;
   }
 
   .profileBodyTopEditButton {
@@ -250,6 +270,26 @@ const StyledProfileDetail = styled.div`
     align-items: center;
     color: gray;
   }
+`
+
+const ButtonBlock = styled.div`
+  display: flex;
+  align-items: center;
+`
+
+const PersonalButtonBlock = styled.div``
+
+const FollowButtonBlock = styled.div``
+
+const MessageButton = styled(Button)`
+  background-color: black !important;
+  color: white !important;
+  font-weight: 900 !important;
+  width: 180px !important;
+  height: 40px !important;
+  border-radius: 30px !important;
+  margin-left: auto !important;
+  margin-right: 10px !important;
 `
 
 const FollowButton = styled(Button)`

--- a/src/components/pages/DirectMessage.tsx
+++ b/src/components/pages/DirectMessage.tsx
@@ -1,0 +1,61 @@
+import styled from 'styled-components'
+import { SideBar } from '../templates/SideBar'
+import { Groups } from '../organisms/Groups'
+import { Messages } from '../organisms/Messages'
+import { MessageBox } from '../organisms/MessageBox'
+
+export const DirectMessage: React.FC = () => {
+  return (
+    <StyledDirectMessage>
+      <SideBarBlock>
+        <SideBar />
+      </SideBarBlock>
+      <DirectMessageBlock>
+        <GroupBlock>
+          <Groups />
+        </GroupBlock>
+        <MessageBlock>
+          <MessageHeader>
+            <h2>Group Name</h2>
+          </MessageHeader>
+          <Messages />
+          <MessageBox />
+        </MessageBlock>
+      </DirectMessageBlock>
+    </StyledDirectMessage>
+  )
+}
+
+const StyledDirectMessage = styled.div`
+  display: flex;
+  height: 100vh;
+  max-width: 1000px;
+  margin: 0 auto;
+  padding: 0 10px;
+`
+
+const SideBarBlock = styled.div`
+  border-right: 1px solid var(--twitter-background);
+  min-width: 300px;
+  margin-top: 20px;
+  padding-left: 20px;
+  padding-right: 20px;
+`
+
+const DirectMessageBlock = styled.div`
+  display: flex;
+`
+
+const GroupBlock = styled.div`
+  min-width: 250px;
+  border-right: 1px solid var(--twitter-background);
+`
+
+const MessageHeader = styled.div`
+  padding: 10px 10px;
+`
+
+const MessageBlock = styled.div`
+  min-width: 450px;
+  border-right: 1px solid var(--twitter-background);
+`

--- a/src/components/pages/DirectMessage.tsx
+++ b/src/components/pages/DirectMessage.tsx
@@ -3,8 +3,39 @@ import { SideBar } from '../templates/SideBar'
 import { Groups } from '../organisms/Groups'
 import { Messages } from '../organisms/Messages'
 import { MessageBox } from '../organisms/MessageBox'
+import { useEffect, useState } from 'react'
+import { getGroups } from '../../lib/api/group'
+
+type User = {
+  id: number
+  name: string
+  nickname: string
+  avatarImageUrl: string
+}
+
+type Group = {
+  id: number
+  user: User
+}
 
 export const DirectMessage: React.FC = () => {
+  const [groups, setGroups] = useState<Group[]>([])
+
+  const handleGetGroups = () => {
+    getGroups()
+      .then((res) => {
+        const resGroups: Group[] = res.data.groups
+        setGroups(resGroups)
+      })
+      .catch((err) => {
+        console.error(err)
+      })
+  }
+
+  useEffect(() => {
+    handleGetGroups()
+  }, [])
+
   return (
     <StyledDirectMessage>
       <SideBarBlock>
@@ -12,7 +43,7 @@ export const DirectMessage: React.FC = () => {
       </SideBarBlock>
       <DirectMessageBlock>
         <GroupBlock>
-          <Groups />
+          <Groups groups={groups} />
         </GroupBlock>
         <MessageBlock>
           <MessageHeader>

--- a/src/components/pages/DirectMessage.tsx
+++ b/src/components/pages/DirectMessage.tsx
@@ -66,7 +66,7 @@ export const DirectMessage: React.FC = () => {
               <MessageHeader>
                 <h2>{selectedGroup.user.nickname}</h2>
               </MessageHeader>
-              <Messages />
+              <Messages selectedGroup={selectedGroup} />
               <MessageBox />
             </>
           )}

--- a/src/components/pages/DirectMessage.tsx
+++ b/src/components/pages/DirectMessage.tsx
@@ -73,6 +73,24 @@ export const DirectMessage: React.FC = () => {
     handleGetGroups()
   }, [])
 
+  useEffect(() => {
+    const queryParams = new URLSearchParams(location.search)
+    const paramsGroupId = Number(queryParams.get('group_id')) || 0
+
+    console.log(paramsGroupId)
+    console.log(groups)
+
+    if (paramsGroupId !== 0) {
+      const newSelectedGroup = groups.find(
+        (group) => group.id === paramsGroupId
+      )
+
+      if (newSelectedGroup) {
+        setSelectedGroup(newSelectedGroup)
+      }
+    }
+  }, [groups])
+
   return (
     <StyledDirectMessage>
       <SideBarBlock>

--- a/src/components/pages/DirectMessage.tsx
+++ b/src/components/pages/DirectMessage.tsx
@@ -18,8 +18,19 @@ type Group = {
   user: User
 }
 
+const initialGroup: Group = {
+  id: 0,
+  user: {
+    id: 0,
+    name: '',
+    nickname: '',
+    avatarImageUrl: '',
+  },
+}
+
 export const DirectMessage: React.FC = () => {
   const [groups, setGroups] = useState<Group[]>([])
+  const [selectedGroup, setSelectedGroup] = useState<Group>(initialGroup)
 
   const handleGetGroups = () => {
     getGroups()
@@ -43,14 +54,22 @@ export const DirectMessage: React.FC = () => {
       </SideBarBlock>
       <DirectMessageBlock>
         <GroupBlock>
-          <Groups groups={groups} />
+          <Groups
+            groups={groups}
+            selectedGroup={selectedGroup}
+            setSelectedGroup={setSelectedGroup}
+          />
         </GroupBlock>
         <MessageBlock>
-          <MessageHeader>
-            <h2>Group Name</h2>
-          </MessageHeader>
-          <Messages />
-          <MessageBox />
+          {selectedGroup.id !== 0 && (
+            <>
+              <MessageHeader>
+                <h2>{selectedGroup.user.nickname}</h2>
+              </MessageHeader>
+              <Messages />
+              <MessageBox />
+            </>
+          )}
         </MessageBlock>
       </DirectMessageBlock>
     </StyledDirectMessage>

--- a/src/components/pages/DirectMessage.tsx
+++ b/src/components/pages/DirectMessage.tsx
@@ -5,6 +5,7 @@ import { Messages } from '../organisms/Messages'
 import { MessageBox } from '../organisms/MessageBox'
 import { useEffect, useState } from 'react'
 import { getGroups } from '../../lib/api/group'
+import { getMessages } from '../../lib/api/message'
 
 type User = {
   id: number
@@ -16,6 +17,19 @@ type User = {
 type Group = {
   id: number
   user: User
+}
+
+type Message = {
+  id: number
+  message: string
+  user: {
+    id: number
+    name: string
+    nickname: string
+    avatarImageUrl: string
+  }
+  createdAt: string
+  updatedAt: string
 }
 
 const initialGroup: Group = {
@@ -31,12 +45,24 @@ const initialGroup: Group = {
 export const DirectMessage: React.FC = () => {
   const [groups, setGroups] = useState<Group[]>([])
   const [selectedGroup, setSelectedGroup] = useState<Group>(initialGroup)
+  const [messages, setMessages] = useState<Message[]>([])
 
   const handleGetGroups = () => {
     getGroups()
       .then((res) => {
         const resGroups: Group[] = res.data.groups
         setGroups(resGroups)
+      })
+      .catch((err) => {
+        console.error(err)
+      })
+  }
+
+  const handleGetMessages = (groupId: number) => {
+    getMessages(groupId)
+      .then((res) => {
+        const resMessages: Message[] = res.data.messages
+        setMessages(resMessages)
       })
       .catch((err) => {
         console.error(err)
@@ -66,8 +92,15 @@ export const DirectMessage: React.FC = () => {
               <MessageHeader>
                 <h2>{selectedGroup.user.nickname}</h2>
               </MessageHeader>
-              <Messages selectedGroup={selectedGroup} />
-              <MessageBox />
+              <Messages
+                messages={messages}
+                selectedGroup={selectedGroup}
+                handleGetMessages={handleGetMessages}
+              />
+              <MessageBox
+                groupId={selectedGroup.id}
+                handleGetMessages={handleGetMessages}
+              />
             </>
           )}
         </MessageBlock>

--- a/src/components/pages/Home.tsx
+++ b/src/components/pages/Home.tsx
@@ -19,7 +19,7 @@ export const Home: React.FC = () => {
 const StyledHome = styled.div`
   display: flex;
   height: 100vh;
-  max-width: 900px;
+  max-width: 1000px;
   margin: 0 auto;
   padding: 0 10px;
 
@@ -32,7 +32,7 @@ const StyledHome = styled.div`
   }
 
   .timeLine {
-    min-width: 600px;
+    min-width: 700px;
     border-right: 1px solid var(--twitter-background);
     overflow-y: scroll;
   }

--- a/src/components/pages/Notice.tsx
+++ b/src/components/pages/Notice.tsx
@@ -18,7 +18,7 @@ export const Notice: React.FC = () => {
 const StyledNotice = styled.div`
   display: flex;
   height: 100vh;
-  max-width: 900px;
+  max-width: 1000px;
   margin: 0 auto;
   padding: 0 10px;
 `
@@ -32,7 +32,7 @@ const SideBarBlock = styled.div`
 `
 
 const NotificationBlock = styled.div`
-  min-width: 600px;
+  min-width: 700px;
   border-right: 1px solid var(--twitter-background);
   overflow-y: scroll;
 `

--- a/src/components/pages/PostDetail.tsx
+++ b/src/components/pages/PostDetail.tsx
@@ -23,7 +23,7 @@ export const PostDetail: React.FC = () => {
 const StyledPostDetail = styled.div`
   display: flex;
   height: 100vh;
-  max-width: 900px;
+  max-width: 1000px;
   margin: 0 auto;
   padding: 0 10px;
 
@@ -36,7 +36,7 @@ const StyledPostDetail = styled.div`
   }
 
   .post {
-    min-width: 600px;
+    min-width: 700px;
     border-right: 1px solid var(--twitter-background);
     overflow-y: scroll;
   }

--- a/src/components/pages/Profile.tsx
+++ b/src/components/pages/Profile.tsx
@@ -147,7 +147,7 @@ export const Profile: React.FC = () => {
 const StyledHome = styled.div`
   display: flex;
   height: 100vh;
-  max-width: 900px;
+  max-width: 1000px;
   margin: 0 auto;
   padding: 0 10px;
 
@@ -160,7 +160,7 @@ const StyledHome = styled.div`
   }
 
   .profile {
-    min-width: 600px;
+    min-width: 700px;
     border-right: 1px solid var(--twitter-background);
     overflow-y: scroll;
   }

--- a/src/lib/api/group.ts
+++ b/src/lib/api/group.ts
@@ -1,0 +1,5 @@
+import client from './client'
+
+export const getGroups = () => {
+  return client.get(`groups`)
+}

--- a/src/lib/api/group.ts
+++ b/src/lib/api/group.ts
@@ -3,3 +3,7 @@ import client from './client'
 export const getGroups = () => {
   return client.get(`groups`)
 }
+
+export const findOrCreateGroup = (userId: number) => {
+  return client.post(`groups`, { userId })
+}

--- a/src/lib/api/message.ts
+++ b/src/lib/api/message.ts
@@ -1,0 +1,5 @@
+import client from './client'
+
+export const getMessages = (groupId: number) => {
+  return client.get(`groups/${groupId}/messages`)
+}

--- a/src/lib/api/message.ts
+++ b/src/lib/api/message.ts
@@ -3,3 +3,7 @@ import client from './client'
 export const getMessages = (groupId: number) => {
   return client.get(`groups/${groupId}/messages`)
 }
+
+export const sendMessage = (message: string, groupId: number) => {
+  return client.post(`groups/${groupId}/messages`, { message })
+}

--- a/src/validators/messageValidator.ts
+++ b/src/validators/messageValidator.ts
@@ -1,0 +1,9 @@
+export const validateDirectMessage = (message: string): string => {
+  if (message.length === 0) {
+    return 'メッセージは必須です'
+  }
+  if (message.length > 100) {
+    return 'メッセージは100文字以内で入力してください'
+  }
+  return ''
+}


### PR DESCRIPTION
## 課題のリンク

* https://github.com/happiness-chain/practice/blob/main/14.2_react/003_%E8%AA%B2%E9%A1%8C.md#%E3%83%80%E3%82%A4%E3%83%AC%E3%82%AF%E3%83%88%E3%83%A1%E3%83%83%E3%82%BB%E3%83%BC%E3%82%B8

## やったこと

* メッセージ画面を追加した
* サイドバーからメッセージ画面に遷移できるようにした
* メッセージ画面のwidthを1000pxにしたので、他の画面も合わせた

## やらなかったこと

* グループ一覧、メッセージ一覧のページネーション対応
* styled-componentのスタイルの当て方が統一されていないが、特に対応していない

## 動作確認方法

### 準備

1. [会員登録画面](https://8tako8tako8.github.io/twitter_react/registration) または [ログイン画面](https://8tako8tako8.github.io/twitter_react/login)にアクセスし、ログインする
2. 他のユーザーが投稿したツイートのユーザー名からプロフィール画面に遷移する

### 動作確認

* ✅ プロフィール画面に「メッセージを送る」ボタンが表示されること
* ✅ 「メッセージを送る」ボタンを押下してメッセージ画面に遷移できること
* ✅ メッセージを送信できること
* ✅ メッセージが100文字超えの場合にエラーが表示されること
* ✅ 特定のグループをクリックすると、メッセージ一覧が表示されること
* ✅ サイドバーからメッセージ画面に遷移できること

## キャプチャ

* <img width="700" alt="image" src="https://github.com/8tako8tako8/twitter_react/assets/65395999/713b02ed-3e14-440a-9bb4-4b03dbe4bf16">
* <img width="700" alt="image" src="https://github.com/8tako8tako8/twitter_react/assets/65395999/e00337b7-57fb-4a1e-9644-1f520af201fe">
* <img width="700" alt="image" src="https://github.com/8tako8tako8/twitter_react/assets/65395999/386ea39c-6029-4302-81e1-2dff27b72bc1">

## その他

なし
