### PR TITLE
退会機能を追加

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,7 @@ import { PostDetail } from './components/pages/PostDetail'
 import { Profile } from './components/pages/Profile'
 import { Notice } from './components/pages/Notice'
 import { DirectMessage } from './components/pages/DirectMessage'
+import { Bookmark } from './components/pages/Bookmark'
 
 export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector
 export const useAppDispatch = () => useDispatch<AppDispatch>()
@@ -75,6 +76,10 @@ const App: React.FC = () => {
         <Route
           path={homeUrl + '/messages'}
           element={<PrivateRoute children={<DirectMessage />} />}
+        />
+        <Route
+          path={homeUrl + '/bookmarks'}
+          element={<PrivateRoute children={<Bookmark />} />}
         />
         <Route path="*" element={<Error />} />
       </Routes>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,7 @@ import { Profile } from './components/pages/Profile'
 import { Notice } from './components/pages/Notice'
 import { DirectMessage } from './components/pages/DirectMessage'
 import { Bookmark } from './components/pages/Bookmark'
+import { Withdrawal } from './components/pages/Withdrawal'
 
 export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector
 export const useAppDispatch = () => useDispatch<AppDispatch>()
@@ -80,6 +81,10 @@ const App: React.FC = () => {
         <Route
           path={homeUrl + '/bookmarks'}
           element={<PrivateRoute children={<Bookmark />} />}
+        />
+        <Route
+          path={homeUrl + '/withdrawal'}
+          element={<PrivateRoute children={<Withdrawal />} />}
         />
         <Route path="*" element={<Error />} />
       </Routes>

--- a/src/components/organisms/BookmarkPosts.tsx
+++ b/src/components/organisms/BookmarkPosts.tsx
@@ -1,0 +1,121 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { Pagination } from '@mui/material'
+import styled from 'styled-components'
+import { Loading } from '../pages/Loading'
+import { useNavigate } from 'react-router-dom'
+import { useEffect, useState } from 'react'
+import { getBookmarks } from '../../lib/api/bookmark'
+import { Post } from './Post'
+
+type Post = {
+  id: number
+  user: {
+    id: string
+    name: string
+    nickname: string
+    avatarImageUrl: string
+  }
+  tweet: string
+  imageUrl: string
+  isRetweeted: boolean
+  isFavorited: boolean
+  isBookmarked: boolean
+  retweets: number
+  favorites: number
+}
+
+export const BookmarkPosts: React.FC = () => {
+  const [bookmarks, setBookmarks] = useState<Post[]>([])
+  const [loading, setLoading] = useState<boolean>(false)
+  const [currentPage, setCurrentPage] = useState(1)
+  const [totalPages, setTotalPages] = useState(1)
+
+  const navigate = useNavigate()
+
+  const handleChangePage = (
+    _event: React.ChangeEvent<unknown>,
+    page: number
+  ) => {
+    setCurrentPage(page)
+    navigate({ ...location, search: `?page=${page}` })
+    handleGetBookmarks(page)
+  }
+
+  const handleGetBookmarks = (page: number) => {
+    setLoading(true)
+
+    getBookmarks(page)
+      .then((res) => {
+        if (res && res.data) {
+          setTotalPages((res.data.pagination.totalPages as number) || 1)
+          const resBookmarks: Post[] = res.data.bookmarks
+          setBookmarks(resBookmarks)
+        }
+      })
+      .catch((err) => {
+        console.error(err)
+      })
+      .finally(() => {
+        setLoading(false)
+      })
+  }
+
+  useEffect(() => {
+    //  クエリパラメータからpageを取得する
+    const queryParams = new URLSearchParams(location.search)
+    const page = Number(queryParams.get('page')) || 1
+
+    setCurrentPage(page)
+    handleGetBookmarks(page)
+  }, [location.search])
+
+  if (loading) {
+    return <Loading />
+  }
+
+  return (
+    <StyledBookmarkPosts>
+      <BookmarkHeader>
+        <HeaderText>ブックマーク</HeaderText>
+      </BookmarkHeader>
+
+      {bookmarks.map((bookmark) => (
+        <Post key={bookmark.id} post={bookmark} myself={false} />
+      ))}
+      <PaginationBlock>
+        <Pagination
+          count={totalPages}
+          page={currentPage}
+          variant="outlined"
+          color="primary"
+          size="small"
+          onChange={handleChangePage}
+        />
+      </PaginationBlock>
+    </StyledBookmarkPosts>
+  )
+}
+
+const StyledBookmarkPosts = styled.div``
+
+const BookmarkHeader = styled.div`
+  position: sticky;
+  top: 0;
+  background-color: white;
+  z-index: 100;
+  border: 1px solid var(--twitter-background);
+  padding: 5px 20px;
+`
+
+const HeaderText = styled.h2`
+  font-size: 20px;
+  font-weight: 800;
+`
+
+const PaginationBlock = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-top: 20px;
+  margin-bottom: 20px;
+`

--- a/src/components/organisms/Post.tsx
+++ b/src/components/organisms/Post.tsx
@@ -1,8 +1,9 @@
 import {
-  ChatBubbleOutline,
   FavoriteBorder,
   Repeat,
   VerifiedUser,
+  BookmarkBorder,
+  Bookmark,
 } from '@mui/icons-material'
 import { MenuItem } from '@mui/material'
 import React, { useEffect, useRef, useState } from 'react'
@@ -13,6 +14,7 @@ import { FlashMessage } from './FlashMessage'
 import { DropDownMenu } from './DropDownMenu'
 import { cancelRetweet, retweet } from '../../lib/api/retweet'
 import { cancelFavorite, favorite } from '../../lib/api/favorite'
+import { bookmark, cancelBookmark } from '../../lib/api/bookmark'
 
 type Post = {
   id: number
@@ -26,6 +28,7 @@ type Post = {
   imageUrl: string
   isRetweeted: boolean
   isFavorited: boolean
+  isBookmarked: boolean
   retweets: number
   favorites: number
 }
@@ -44,6 +47,7 @@ export const Post: React.FC<Props> = ({ post, myself, handleGetProfile }) => {
   const [openErrorMessage, setOpenErrorMessage] = useState(false)
   const [isRetweeted, setIsRetweeted] = useState(post.isRetweeted)
   const [isFavorited, setIsFavorited] = useState(post.isFavorited)
+  const [isBookmarked, setIsBookmarked] = useState(post.isBookmarked)
   const [retweets, setRetweets] = useState(post.retweets)
   const [favorites, setFavorites] = useState(post.favorites)
 
@@ -62,6 +66,30 @@ export const Post: React.FC<Props> = ({ post, myself, handleGetProfile }) => {
         setOpenErrorMessage(true)
       })
     setOpenMenu(false)
+  }
+
+  const handleBookmark = () => {
+    bookmark(post.id)
+      .then((res) => {
+        if (res.status != 200) throw new Error('ブックマークに失敗しました')
+
+        setIsBookmarked(true)
+      })
+      .catch((err) => {
+        console.error(err)
+      })
+  }
+
+  const handleCancelBookmark = () => {
+    cancelBookmark(post.id)
+      .then((res) => {
+        if (res.status != 200) throw new Error('ブックマーク解除に失敗しました')
+
+        setIsBookmarked(false)
+      })
+      .catch((err) => {
+        console.error(err)
+      })
   }
 
   const handleRetweet = () => {
@@ -179,7 +207,14 @@ export const Post: React.FC<Props> = ({ post, myself, handleGetProfile }) => {
           </PostCardBodyTop>
           {post.imageUrl && <PostImage src={post.imageUrl} />}
           <PostFooter>
-            <ChatBubbleOutline fontSize="small" />
+            <BookmarkBlock>
+              {!isBookmarked && (
+                <BookmarkBorderIcon fontSize="small" onClick={handleBookmark} />
+              )}
+              {isBookmarked && (
+                <BookmarkIcon fontSize="small" onClick={handleCancelBookmark} />
+              )}
+            </BookmarkBlock>
             <RetweetBlock>
               {!isRetweeted && (
                 <>
@@ -302,6 +337,16 @@ const PostFooter = styled.div`
   margin-top: 10px;
   margin-bottom: 10px;
   margin-right: 10px;
+`
+
+const BookmarkBlock = styled.div``
+
+const BookmarkIcon = styled(Bookmark)`
+  cursor: pointer;
+`
+
+const BookmarkBorderIcon = styled(BookmarkBorder)`
+  cursor: pointer;
 `
 
 const RetweetBlock = styled.div`

--- a/src/components/organisms/PostDetailBox.tsx
+++ b/src/components/organisms/PostDetailBox.tsx
@@ -1,5 +1,6 @@
 import {
-  ChatBubbleOutline,
+  Bookmark,
+  BookmarkBorder,
   FavoriteBorder,
   Repeat,
   VerifiedUser,
@@ -13,6 +14,7 @@ import { Loading } from '../pages/Loading'
 import { cancelRetweet, retweet } from '../../lib/api/retweet'
 import { cancelFavorite, favorite } from '../../lib/api/favorite'
 import { Link } from 'react-router-dom'
+import { bookmark, cancelBookmark } from '../../lib/api/bookmark'
 
 type Post = {
   id: number
@@ -26,6 +28,7 @@ type Post = {
   imageUrl: string
   isRetweeted: boolean
   isFavorited: boolean
+  isBookmarked: boolean
   retweets: number
   favorites: number
 }
@@ -44,16 +47,7 @@ export const PostDetailBox: React.FC = () => {
     getPost(tweetId)
       .then((res) => {
         if (res && res.data) {
-          const resPost: Post = {
-            id: res.data.id,
-            user: res.data.user,
-            tweet: res.data.tweet,
-            imageUrl: res.data.imageUrl,
-            isRetweeted: res.data.isRetweeted,
-            isFavorited: res.data.isFavorited,
-            retweets: res.data.retweets,
-            favorites: res.data.favorites,
-          }
+          const resPost: Post = res.data
           setPost(resPost)
         }
       })
@@ -62,6 +56,34 @@ export const PostDetailBox: React.FC = () => {
       })
       .finally(() => {
         setLoading(false)
+      })
+  }
+
+  const handleBookmark = () => {
+    if (!post) return
+
+    bookmark(post.id)
+      .then((res) => {
+        if (res.status != 200) throw new Error('ブックマークに失敗しました')
+
+        setPost({ ...post, isBookmarked: true })
+      })
+      .catch((err) => {
+        console.error(err)
+      })
+  }
+
+  const handleCancelBookmark = () => {
+    if (!post) return
+
+    cancelBookmark(post.id)
+      .then((res) => {
+        if (res.status != 200) throw new Error('ブックマーク解除に失敗しました')
+
+        setPost({ ...post, isBookmarked: false })
+      })
+      .catch((err) => {
+        console.error(err)
       })
   }
 
@@ -158,7 +180,12 @@ export const PostDetailBox: React.FC = () => {
             <span>{post?.favorites} 件のいいね</span>
           </div>
           <div className="postFooter">
-            <ChatBubbleOutline fontSize="small" />
+            {post?.isBookmarked && (
+              <BookmarkIcon fontSize="small" onClick={handleCancelBookmark} />
+            )}
+            {!post?.isBookmarked && (
+              <BookmarkBorderIcon fontSize="small" onClick={handleBookmark} />
+            )}
             {post?.isRetweeted && (
               <RetweetIcon
                 fontSize="small"
@@ -179,7 +206,6 @@ export const PostDetailBox: React.FC = () => {
             {!post?.isFavorited && (
               <FavoriteIcon fontSize="small" onClick={handleFavorite} />
             )}
-            {/* <FavoriteBorder fontSize="small" /> */}
           </div>
         </div>
       </div>
@@ -274,5 +300,13 @@ const RetweetIcon = styled(Repeat)`
 `
 
 const FavoriteIcon = styled(FavoriteBorder)`
+  cursor: pointer;
+`
+
+const BookmarkIcon = styled(Bookmark)`
+  cursor: pointer;
+`
+
+const BookmarkBorderIcon = styled(BookmarkBorder)`
   cursor: pointer;
 `

--- a/src/components/organisms/Posts.tsx
+++ b/src/components/organisms/Posts.tsx
@@ -16,6 +16,7 @@ type Post = {
   imageUrl: string
   isRetweeted: boolean
   isFavorited: boolean
+  isBookmarked: boolean
   retweets: number
   favorites: number
 }

--- a/src/components/organisms/ProfileDetail.tsx
+++ b/src/components/organisms/ProfileDetail.tsx
@@ -35,6 +35,7 @@ type Post = {
   imageUrl: string
   isRetweeted: boolean
   isFavorited: boolean
+  isBookmarked: boolean
   retweets: number
   favorites: number
 }

--- a/src/components/organisms/ProfileDetailModal.tsx
+++ b/src/components/organisms/ProfileDetailModal.tsx
@@ -37,6 +37,7 @@ type Post = {
   imageUrl: string
   isRetweeted: boolean
   isFavorited: boolean
+  isBookmarked: boolean
   retweets: number
   favorites: number
 }

--- a/src/components/organisms/SideBarOptionList.tsx
+++ b/src/components/organisms/SideBarOptionList.tsx
@@ -51,8 +51,8 @@ export const SideBarOptionList: React.FC = () => {
     {
       text: '退会',
       icon: MoreHorizIcon,
-      linkTo: `${homeUrl}/cancel`,
-      isActive: location.pathname === '/cancel',
+      linkTo: `${homeUrl}/withdrawal`,
+      isActive: location.pathname === '/withdrawal',
     },
   ]
 

--- a/src/components/organisms/VariousPosts.tsx
+++ b/src/components/organisms/VariousPosts.tsx
@@ -16,6 +16,7 @@ type Post = {
   imageUrl: string
   isRetweeted: boolean
   isFavorited: boolean
+  isBookmarked: boolean
   retweets: number
   favorites: number
 }

--- a/src/components/pages/Bookmark.tsx
+++ b/src/components/pages/Bookmark.tsx
@@ -1,0 +1,39 @@
+import React from 'react'
+import { styled } from 'styled-components'
+import { SideBar } from '../templates/SideBar'
+import { BookmarkPosts } from '../organisms/BookmarkPosts'
+
+export const Bookmark: React.FC = () => {
+  return (
+    <StyledHome>
+      <SideBarBlock>
+        <SideBar />
+      </SideBarBlock>
+      <BookmarkPostsBlock>
+        <BookmarkPosts></BookmarkPosts>
+      </BookmarkPostsBlock>
+    </StyledHome>
+  )
+}
+
+const StyledHome = styled.div`
+  display: flex;
+  height: 100vh;
+  max-width: 1000px;
+  margin: 0 auto;
+  padding: 0 10px;
+`
+
+const SideBarBlock = styled.div`
+  border-right: 1px solid var(--twitter-background);
+  min-width: 300px;
+  margin-top: 20px;
+  padding-left: 20px;
+  padding-right: 20px;
+`
+
+const BookmarkPostsBlock = styled.div`
+  min-width: 700px;
+  border-right: 1px solid var(--twitter-background);
+  overflow-y: scroll;
+`

--- a/src/components/pages/Login.tsx
+++ b/src/components/pages/Login.tsx
@@ -58,8 +58,8 @@ export const Login: React.FC = () => {
         }
       })
       .catch((err) => {
-        if (typeof err.response?.data?.errors[0] === 'string') {
-          setErrorMessage(err.response.data.errors[0])
+        if (typeof err.response?.data?.errors === 'string') {
+          setErrorMessage(err.response.data.errors as string)
         } else {
           console.error(err)
           setErrorMessage('不明なエラー。しばらく時間をおいて試してください。')

--- a/src/components/pages/Profile.tsx
+++ b/src/components/pages/Profile.tsx
@@ -46,6 +46,7 @@ type Post = {
   imageUrl: string
   isRetweeted: boolean
   isFavorited: boolean
+  isBookmarked: boolean
   retweets: number
   favorites: number
 }

--- a/src/components/pages/Withdrawal.tsx
+++ b/src/components/pages/Withdrawal.tsx
@@ -1,0 +1,79 @@
+import React, { useState } from 'react'
+import styled from 'styled-components'
+import { ErrorMessage } from '../organisms/ErrorMessage'
+import { withdrawal } from '../../lib/api/auth'
+
+export const Withdrawal: React.FC = () => {
+  const [errorMessage, setErrorMessage] = useState('')
+  const [isWithdrawal, setIsWithdrawal] = useState(false)
+
+  const handleWithdrawal = (e: React.FormEvent) => {
+    e.preventDefault()
+
+    withdrawal()
+      .then((res) => {
+        if (res.status != 200) throw new Error('退会に失敗しました')
+
+        setIsWithdrawal(true)
+      })
+      .catch((err) => {
+        console.error(err)
+        setErrorMessage((err.message || err) as string)
+      })
+  }
+
+  return (
+    <StyledWithdrawal>
+      {!isWithdrawal && (
+        <>
+          <HeadingText>退会</HeadingText>
+          <DescriptionText>退会しますか？</DescriptionText>
+          <WithdrawalForm onSubmit={handleWithdrawal}>
+            <WithdrawalButton type="submit">退会する</WithdrawalButton>
+          </WithdrawalForm>
+          {errorMessage !== '' && <ErrorMessage>{errorMessage}</ErrorMessage>}
+        </>
+      )}
+      {isWithdrawal && (
+        <>
+          <HeadingText>退会完了</HeadingText>
+          <DescriptionText>ありがとうございました</DescriptionText>
+        </>
+      )}
+    </StyledWithdrawal>
+  )
+}
+
+const StyledWithdrawal = styled.div`
+  width: 300px;
+  margin: 0 auto;
+  padding: 20px;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+  border-radius: 8px;
+`
+
+const HeadingText = styled.h1`
+  text-align: center;
+  margin-bottom: 20px;
+`
+
+const DescriptionText = styled.p``
+
+const WithdrawalForm = styled.form`
+  margin-bottom: 10px;
+`
+
+const WithdrawalButton = styled.button`
+  width: 100%;
+  padding: 10px;
+  background-color: #007bff;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background-color 0.2s;
+
+  &:hover {
+    background-color: #0056b3;
+  }
+`

--- a/src/components/templates/TimeLine.tsx
+++ b/src/components/templates/TimeLine.tsx
@@ -17,6 +17,7 @@ type Post = {
   imageUrl: string
   isRetweeted: boolean
   isFavorited: boolean
+  isBookmarked: boolean
   retweets: number
   favorites: number
 }

--- a/src/lib/api/auth.ts
+++ b/src/lib/api/auth.ts
@@ -31,3 +31,8 @@ export const getCurrentUser = () => {
     },
   })
 }
+
+// 退会
+export const withdrawal = () => {
+  return client.delete('users')
+}

--- a/src/lib/api/auth.ts
+++ b/src/lib/api/auth.ts
@@ -23,7 +23,7 @@ export const getCurrentUser = () => {
     return
 
   // prettier-ignore
-  return client.get('/auth/sessions', {
+  return client.get('user_session', {
     headers: {
       "access-token": Cookies.get("_access_token"),
       "client": Cookies.get("_client"),

--- a/src/lib/api/bookmark.ts
+++ b/src/lib/api/bookmark.ts
@@ -1,0 +1,9 @@
+import client from './client'
+
+export const bookmark = (tweetId: number) => {
+  return client.post(`bookmarks`, { tweet_id: tweetId })
+}
+
+export const cancelBookmark = (tweetId: number) => {
+  return client.delete(`bookmarks`, { data: { tweet_id: tweetId } })
+}

--- a/src/lib/api/bookmark.ts
+++ b/src/lib/api/bookmark.ts
@@ -1,9 +1,20 @@
 import client from './client'
 
+const BOOKMARKS_PER_PAGE = 10
+
 export const bookmark = (tweetId: number) => {
   return client.post(`bookmarks`, { tweet_id: tweetId })
 }
 
 export const cancelBookmark = (tweetId: number) => {
   return client.delete(`bookmarks`, { data: { tweet_id: tweetId } })
+}
+
+export const getBookmarks = (currentPage: number) => {
+  return client.get(`bookmarks`, {
+    params: {
+      limit: BOOKMARKS_PER_PAGE,
+      offset: currentPage,
+    },
+  })
 }


### PR DESCRIPTION
## 課題のリンク

* https://github.com/happiness-chain/practice/blob/main/14.2_react/003_%E8%AA%B2%E9%A1%8C.md#%E9%80%80%E4%BC%9A

## やったこと

* 退会画面を追加しました
* サイドバーから退会画面に遷移できるようにしました

## やらなかったこと

* ログイン画面に会員登録導線がありませんが、このPRでは対応していません

## 動作確認方法

### 準備
1. [会員登録画面](https://8tako8tako8.github.io/twitter_react/registration) または [ログイン画面](https://8tako8tako8.github.io/twitter_react/login)にアクセスし、ログインする

### 動作確認

* ✅ サイドバーから退会画面に遷移できること
* ✅ 退会画面で退会できること
* ✅ 退会後にそのユーザーでログインするとエラーになること
* ✅ 退会済みユーザーがホームに遷移したとき、ログイン画面にリダイレクトされること

## キャプチャ

* <img width="700" alt="image" src="https://github.com/8tako8tako8/twitter_react/assets/65395999/3a019c5f-741b-481f-90f8-eac487240f20">

## その他

なし
